### PR TITLE
Problem loading core scripts on Heroku

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -73,7 +73,7 @@ else
   robot = new Hubot scriptsPath, Options.name
   robot.enableSlash = Options.enableSlash
 
-  scriptsPath = Path.resolve "src", "hubot", "scripts"
+  scriptsPath = Path.resolve __dirname, "..", "src", "hubot", "scripts"
   console.log "Loading hubot core scripts for relative scripts at #{scriptsPath}"
   robot.load scriptsPath
 


### PR DESCRIPTION
Using NPM to load Hubot on Heroku fails to load the core scripts (that is to say, using the basic heroku template by itself, without hubot as part of the repository)

The following is in the logs: `Loading hubot core scripts for relative scripts at /app/src/hubot/scripts` when in reality the core scripts live in `/app/node_modules/hubot/src/hubot/scripts`

I believe this change _should_ fix things, though it’s a little tricky to test without the changes actually being in the npm version.
