### PR TITLE
use PORT env var for Twilio SMS callback URL server

### DIFF
--- a/src/hubot/twilio.coffee
+++ b/src/hubot/twilio.coffee
@@ -37,7 +37,7 @@ class Twilio extends Robot
       response.writeHead 200, 'Content-Type': 'text/plain'
       response.end()
 
-    server.listen (parseInt(process.env.HUBOT_SMS_PORT) || 8080), "0.0.0.0"
+    server.listen (parseInt(process.env.PORT) || 8080), "0.0.0.0"
 
   handle: (body, from) ->
     return if body.length == 0


### PR DESCRIPTION
Those responsible for submitting a pull request that supposedly fixed this before have been sacked.
