### PR TITLE
More explicit campfire errors

### DIFF
--- a/src/hubot/campfire.coffee
+++ b/src/hubot/campfire.coffee
@@ -177,7 +177,10 @@ class CampfireStreaming extends EventEmitter
         data += chunk
       response.on "end", ->
         if response.statusCode >= 400
-          console.log "campfire error: #{response.statusCode}"
+          switch response.statusCode
+            when 401 then throw new Error("Invalid access token provided, campfire refused the authentication")
+            else console.log "campfire error: #{err}"
+
 
         try
           callback null, JSON.parse(data)


### PR DESCRIPTION
This provides more explicit campfire errors for the following cases :
- If the token, rooms or account environment vars aren't defined
- If campfire returns a 401 error (the token is invalid)
