### PR TITLE
Support IRC passwords

### DIFF
--- a/src/hubot/irc.coffee
+++ b/src/hubot/irc.coffee
@@ -31,9 +31,9 @@ class IrcBot extends Robot
     next_id = 1
     user_id = {}
 
-    if options.nickpass != 'undefined'
+    if options.nickpass?
       bot.addListener 'notice', (from, to, text) ->
-        if from == 'NickServ' and text.match new RegExp "^This nickname is registered"
+        if from == 'NickServ' and text.indexOf('registered') != -1
           bot.say 'NickServ', "identify #{options.nickpass}"
 
     bot.addListener 'message', (from, toRoom, message) ->


### PR DESCRIPTION
Hi! This change adds support for authenticating to an IRC server, so that hubot can be used with private internet servers. It uses two new optional environment variables:
- `HUBOT_IRC_PASSWORD`
- `HUBOT_IRC_NICKSERV_PASSWORD`

I'm not so familiar with CoffeeScript so let me know if this is broken somehow. Thanks!
