### PR TITLE
Persist IRC users

### DIFF
--- a/src/hubot/irc.coffee
+++ b/src/hubot/irc.coffee
@@ -57,6 +57,16 @@ class IrcBot extends Robot
 
       self.receive new Robot.TextMessage(user, message)
 
+    bot.addListener 'names', (channel, names) ->
+      for name of names
+        self.userForId(name.toLowerCase(), {name: name})
+
+    bot.addListener 'join', (channel, name) ->
+      self.userForId(name.toLowerCase(), {name: name})
+
+    bot.addListener 'nick', (oldName, newName, channel) ->
+      self.userForId(newName.toLowerCase(), {name: newName})
+
     bot.addListener 'error', (message) ->
         console.error('ERROR: %s: %s', message.command, message.args.join(' '))
 


### PR DESCRIPTION
Hi! These changes cause the IrcRobot to use Users that are persisted in the robot brain, as the other adapters do.

Seems like over time in a public channel many barely used Users will accumulate, but for the private workgroup uses hubot seems suited for that oughtn't be a big problem. Let me know if this seems broken somehow. Thanks!
