### PR TITLE
Persist users in XMPP adapter

### DIFF
--- a/src/hubot/xmpp.coffee
+++ b/src/hubot/xmpp.coffee
@@ -131,7 +131,7 @@ class XmppBot extends Robot
     for str in strings
       console.log "Sending to #{user.room}: #{str}"
 
-      to = if user.type in ['direct', 'chat'] then user.room + '/' + user.id else user.room
+      to = if user.type in ['direct', 'chat'] then "#{user.room}/#{user.id}" else user.room
 
       message = new Xmpp.Element('message',
                   from: @options.username


### PR DESCRIPTION
Currently just using nicknames as the ID -- I'd like to expand this to use JIDs as actual user IDs, but that won't work in semi-anonymous rooms. This also includes some general improvement to presence handling.
