### PR TITLE
Fix IRC msg replies

### DIFF
--- a/src/hubot/irc.coffee
+++ b/src/hubot/irc.coffee
@@ -41,6 +41,7 @@ class IrcBot extends Robot
           password: options.password,
           debug: true,
           port: options.port,
+          stripColors: true,
         }
 
     unless options.nickpass


### PR DESCRIPTION
When the bot receives a msg directed at the bot, like

/msg hubot hubot: help

It replies to hubot instead of the message sender. This commit fixes that.
