### PR TITLE
user#name is not persisted into the options in IRC adapter

### DIFF
--- a/src/hubot/irc.coffee
+++ b/src/hubot/irc.coffee
@@ -55,6 +55,7 @@ class IrcBot extends Robot
           next_id = next_id + 1
 
       user = new Robot.User user_id[from], {
+        name: from,
         room: toRoom,
       }
 


### PR DESCRIPTION
It will show user.name as undefined now because it's not persisted into the options
