### PR TITLE
emit a loaded event in mergeData

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -214,7 +214,7 @@ class Robot.Brain extends EventEmitter
     for k of (data or { })
       @data[k] = data[k]
       
-    @emit 'loaded'
+    @emit 'loaded', @data
 
 class Robot.Message
   # Represents an incoming message from the chat.


### PR DESCRIPTION
Emit an event after mergeData is finished (as used by redis-brain) so we don't have to do hacky workarounds in scripts (see remind.coffee for an example).
