### PR TITLE
Use the bot's address name for the IRC nick if one isn't specified

### DIFF
--- a/src/hubot/irc.coffee
+++ b/src/hubot/irc.coffee
@@ -30,7 +30,7 @@ class IrcBot extends Robot
     self = @
 
     options =
-      nick:     process.env.HUBOT_IRC_NICK
+      nick:     process.env.HUBOT_IRC_NICK or @name
       port:     process.env.HUBOT_IRC_PORT
       rooms:    process.env.HUBOT_IRC_ROOMS.split(",")
       server:   process.env.HUBOT_IRC_SERVER


### PR DESCRIPTION
This patch uses the bot's name (the `--name` argument) if no `HUBOT_IRC_NICK` environment variable is set, allowing you to omit the latter when they match (which they should, since otherwise IRC clients' nick completion will help you misaddress the bot).
