### PR TITLE
XMPP adaptor doesn't work with google talk

### DIFF
--- a/src/hubot/xmpp.coffee
+++ b/src/hubot/xmpp.coffee
@@ -6,7 +6,7 @@ class XmppBot extends Robot
     options =
       username: process.env.HUBOT_XMPP_USERNAME
       password: process.env.HUBOT_XMPP_PASSWORD
-      rooms:    process.env.HUBOT_XMPP_ROOMS.split(',') or []
+      rooms:    if process.env.HUBOT_XMPP_ROOMS then process.env.HUBOT_XMPP_ROOMS.split(',') else []
       host:     process.env.HUBOT_XMPP_HOST or null
       port:     process.env.HUBOT_XMPP_PORT or null
       keepaliveInterval: 30000 # ms interval to send whitespace to xmpp server


### PR DESCRIPTION
Needed a few tweaks to allow it to login as a gtalk user and chat.
