### PR TITLE
Add support for secure IRC connections.

### DIFF
--- a/src/hubot/irc.coffee
+++ b/src/hubot/irc.coffee
@@ -44,6 +44,7 @@ class IrcBot extends Robot
           debug: true,
           port: options.port,
           stripColors: true,
+          secure: if options.port is "6697" then true else false,
         }
 
     unless options.nickpass


### PR DESCRIPTION
Hubot was missing support for SSL IRC connections, now it's not :)

It may be better to have an explicit `HUBOT_IRC_SSL` var, rather than inspecting the port number but 6697 is traditionally used for SSL connections.
