### PR TITLE
Updated the help generator to allow for .js scripts to include help lines

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -124,7 +124,7 @@ class Robot
     Fs.readFile path, "utf-8", (err, body) =>
       throw err if err
       for i, line of body.split("\n")
-        break    if line[0] != '#'
+        break    if !(line[0] == '#' or line.substr(0, 2) == '//')
         continue if !line.match('-')
         @commands.push line[2..line.length]
 


### PR DESCRIPTION
I have a couple scripts written in JavaScript (instead of CoffeeScript) and wanted to get the benefit of the help script being able to show my new commands. This simple change lets you do this:

```
// Interacts with the Google Maps API.
//
//map me <query> - Returns a map view of the area returned by `query`.
```

instead of this:

```
# Interacts with the Google Maps API.
#
# map me <query> - Returns a map view of the area returned by `query`.
```
