### PR TITLE
Increase likelihood of getting a gif with animate me.

### DIFF
--- a/src/hubot/scripts/google-images.coffee
+++ b/src/hubot/scripts/google-images.coffee
@@ -13,7 +13,7 @@ module.exports = (robot) ->
       msg.send url
 
   robot.respond /animate me (.*)/i, (msg) ->
-    imageMe msg, "animated #{msg.match[1]}", (url) ->
+    imageMe msg, "animated gif #{msg.match[1]}", (url) ->
       msg.send url
 
   robot.respond /(?:mo?u)?sta(?:s|c)he?(?: me)? (.*)/i, (msg) ->


### PR DESCRIPTION
More often than not, animate me was returning static images.  I found that changing the google images query to include 'gif' returned primarily gifs.
