### PR TITLE
Allow partial matching on user names, and use it for roles.

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -164,20 +164,38 @@ class Robot
 
   # Public: Get a User object given a name
   #
-  userForName: (name, matchPartial = false) ->
+  userForName: (name) ->
     result = null
     lowerName = name.toLowerCase()
     for k of (@brain.data.users or { })
       if @brain.data.users[k]['name'].toLowerCase() is lowerName
         result = @brain.data.users[k]
-
-    if !result? && matchPartial
-      for k of (@brain.data.users or { })
-        if @brain.data.users[k]['name'].toLowerCase().lastIndexOf(lowerName, 0) == 0
-          return null if result? # there were multiple partial matches
-          result = @brain.data.users[k]
+        break
 
     result
+
+  # Public: Get all users whose names match fuzzyName. Currently, match
+  # means 'starts with', but this could be extended to match initials,
+  # nicknames, etc.
+  #
+  usersForRawFuzzyName: (fuzzyName) ->
+    lowerFuzzyName = fuzzyName.toLowerCase()
+    user for key, user of (@brain.data.users or {}) when (
+         user.name.toLowerCase().lastIndexOf(lowerFuzzyName, 0) == 0)
+      
+  # Public: If fuzzyName is an exact match for a user, returns an array with
+  # just that user. Otherwise, returns an array of all users for which
+  # fuzzyName is a raw fuzzy match (see usersForRawFuzzyName).
+  #
+  usersForFuzzyName: (fuzzyName) ->
+    matchedUsers = @usersForRawFuzzyName(fuzzyName);
+    lowerFuzzyName = fuzzyName.toLowerCase()
+    # We can scan matchedUsers rather than all users since usersForRawFuzzyName
+    # will include exact matches
+    for user in matchedUsers
+      return [user] if user.name.toLowerCase() is lowerFuzzyName
+          
+    matchedUsers
 
 class Robot.User
   # Represents a participating user in the chat.


### PR DESCRIPTION
Makes it so the `roles` script matches on partial names (when there's a single unambiguous match). For example, allows me to type

```
/who is Russ?
```

instead of

```
/who is Russell Davis?
```
