### PR TITLE
Campfire: deliver messages in given order

### DIFF
--- a/src/hubot/campfire.coffee
+++ b/src/hubot/campfire.coffee
@@ -4,12 +4,13 @@ EventEmitter = require("events").EventEmitter
 
 class Campfire extends Robot
   send: (user, strings...) ->
-    for str in strings
-      @bot.Room(user.room).speak str, (err, data) ->
+    if strings.length > 0
+      @bot.Room(user.room).speak strings.shift(), (err, data) =>
         console.log "campfire error: #{err}" if err
+        @send user, strings...
 
   reply: (user, strings...) ->
-    @send user, "#{user.name}: #{str}" for str in strings
+    @send user, strings.map((str) -> "#{user.name}: #{str}")...
 
   run: ->
     self = @


### PR DESCRIPTION
This changes the Campfire adapter's mode of sending messages to be "tail-recursive", that is, it calls itself in the callback after the request completes, ensuring that messages are delivered in the order given.
