### PR TITLE
Correctly replace @mentions in Talker adapter

### DIFF
--- a/src/hubot/talker.coffee
+++ b/src/hubot/talker.coffee
@@ -38,8 +38,14 @@ class Talker extends Robot
 
     bot.on "TextMessage", (message)->
       console.log message
+
       author = self.userForId(message.user.id, message.user)
-      self.receive new Robot.TextMessage(author, message.content.replace(/^\s*@hubot\s+/, "Hubot: "))
+
+      # Replace "@mention" with "mention: ", case-insensitively
+      regexp = new RegExp("\\b@#{self.quoteRegex(self.name)}\\b", 'i')
+      content = message.content.replace(regexp, "#{self.name}: ")
+
+      self.receive new Robot.TextMessage(author, content)
 
     bot.on "EnterMessage", (message) ->
       console.log message
@@ -52,6 +58,9 @@ class Talker extends Robot
       self.receive new Robot.LeaveMessage(author)
 
     @bot = bot
+
+  quoteRegex: (string) ->
+    string.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
 
 module.exports = Talker
 


### PR DESCRIPTION
This fixes a problem with how Hubot works in the [Talker](http://talkerapp.com) chat rooms. In Talker, you mention users with the `@user` syntax instead of the IRC-style `user:`.

The talker adapter currently replaced `@hubot` with `Hubot:` but that does not help if the bot isn't named Hubot.

These changes replaces `@<current robot name>` with `<current robot name>:` case-insensitively.

It works like a charm in our chat room.
