### PR TITLE
Change Hubot's default Google Talk status from "Chatty" to "Available"

### DIFF
--- a/src/hubot/gtalk.coffee
+++ b/src/hubot/gtalk.coffee
@@ -28,7 +28,6 @@ class Gtalkbot extends Robot
 
   online: =>
     @client.send new Xmpp.Element('presence')
-      .c('show').t('chat')
 
     # send raw whitespace for keepalive
     setInterval =>


### PR DESCRIPTION
The Google Talk adapter currently defaults Hubot's status to "Chatty", which is somewhat annoying and unnecessary. By removing the `<show />` stanzas when setting Hubot's status via XMPP, Hubot will set it's status to "Available" when it comes online.
