### PR TITLE
Updated node-irc dependency version to address Issue #139. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coffee-script": "1.1.1",
     "optparse": "1.0.1",
     "scoped-http-client": "0.9.0",
-    "irc": "0.2",
+    "irc": "0.3.2",
     "scoped-http-client": "0.9.4",
     "irc": "0.2",
     "node-xmpp": ">=0.2.6",


### PR DESCRIPTION
There seems to be a bug in node-irc (ver 0.2) that causes it to throw an exception when getting the list of users in the channel. Updating to version 3.2 of node-irc seems to address the issue.
