### PR TITLE
Update IrcAdapter to handle userState for brain

### DIFF
--- a/src/hubot/irc.coffee
+++ b/src/hubot/irc.coffee
@@ -63,18 +63,18 @@ class IrcBot extends Robot
 
     bot.addListener 'message', (from, to, message) ->
       console.log "From #{from} to #{to}: #{message}"
+      
+      user = self.userForName from
+      unless user?
+        id = (new Date().getTime() / 1000).toString().replace('.','')
+        user = self.userForId id
+        user.name = from
 
-      if message.match new RegExp "^#{options.nick}", "i"
-        unless user_id[from]
-          user_id[from] = next_id
-          next_id = next_id + 1
-
-      user = new Robot.User user_id[from]
-      user.name = from
       if to.match(/^[&#]/)
         user.room = to
         console.log "#{to} <#{from}> #{message}"
       else
+        user.room = null
         console.log "msg <#{from}> #{message}"
 
       self.receive new Robot.TextMessage(user, message)


### PR DESCRIPTION
The current version of the IRC adapter bypasses the brain entirely when setting up a user for messages.  This fixes that by using Robot.userForName and Robot.userForId to setup the user for the brain to retain.
