### PR TITLE
Allow comma when addressing Hubot

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -48,9 +48,9 @@ class Robot
 
     pattern = re.join("/") # combine the pattern back again
     if @enableSlash
-      newRegex = new RegExp("^(?:\/|#{@name}:?)\\s*(?:#{pattern})", modifiers)
+      newRegex = new RegExp("^(?:\/|#{@name}[:,]?)\\s*(?:#{pattern})", modifiers)
     else
-      newRegex = new RegExp("^#{@name}:?\\s*(?:#{pattern})", modifiers)
+      newRegex = new RegExp("^#{@name}[:,]?\\s*(?:#{pattern})", modifiers)
 
     console.log newRegex.toString()
     @listeners.push new TextListener(@, newRegex, callback)


### PR DESCRIPTION
Allow addressing Hubot with comma in addition to colon.

Using comma to address person (or a bot) feels more natural than colon for me. Plus, it's used as autocomplete in various chat clients. IMHO, Hubot should respond to both "Hubot:" and "Hubot,".
