### PR TITLE
Gtalk Adapter - Accepting Buddy Requests

### DIFF
--- a/src/hubot/gtalk.coffee
+++ b/src/hubot/gtalk.coffee
@@ -86,7 +86,7 @@ class Gtalkbot extends Robot
   handlePresence: (stanza) =>
 
     domainRegexStr = "^*@["+@options.acceptDomains.join('|')+"]$"
-    domainRegex = new RegExp(domainRegex,"i")
+    domainRegex = new RegExp(domainRegexStr,"i")
     # Check for buddy request
     if stanza.attrs.type is 'subscribe' and stanza.attrs.from in @options.acceptUsers or stanza.attrs.from.match(domainRegex)
       @client.send new Xmpp.Element('presence',


### PR DESCRIPTION
For those who do not use the enterprise apps from google. You can now have Hubot accept a request from previously defined list of users or from a list of domains.
### Additional Environment Variables
- `HUBOT_GTALK_WHITELIST_DOMAINS="foo.com,bar.com,domain.com"`
- `HUBOT_GTALK_WHITELIST_USERS="foo@domain.com,bar@otherdomain.com"`
