### PR TITLE
process.ARGV not defined in node 0.6

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -51,7 +51,7 @@ Parser.on "help", (opt, value) ->
 Parser.on "version", (opt, value) ->
   Options.version = true
 
-Parser.parse process.ARGV
+Parser.parse process.argv
 
 process.on 'SIGTERM', -> process.exit(0)
 


### PR DESCRIPTION
In node 0.6, process.ARGV is no longer defined.
Use process.argv instead
