### PR TITLE
allow help to search help commands

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -3,8 +3,12 @@
 # These commands are grabbed from comment blocks at the top of each file.
 #
 # help - Displays all of the help commands that Hubot knows about.
+# help <query> - Displays all help commands that match <query>.
 
 module.exports = (robot) ->
-  robot.respond /help$/i, (msg) ->
-    msg.send robot.helpCommands().join("\n")
+  robot.respond /help\s*(.*)?$/i, (msg) ->
+    cmds = robot.helpCommands()
+    if msg.match[1]
+      cmds = cmds.filter (cmd) -> cmd.match(new RegExp(msg.match[1]))
+    msg.send cmds.join("\n")
 


### PR DESCRIPTION
As we're using more commands, calling help spams a chatroom, especially in irc. Allowing help to search minimizes that spam. Also comes in handy when u want to pull up commands by a certain argument type: `hubot: help <img>` .
