### PR TITLE
Make hipchat plugin less chatty and fix reply syntax.

### DIFF
--- a/src/adapters/hipchat.coffee
+++ b/src/adapters/hipchat.coffee
@@ -4,14 +4,12 @@ Wobot        = require("wobot").Bot
 
 class HipChat extends Robot
   send: (user, strings...) ->
-    console.log "Sending"
     for str in strings
       @bot.message user.reply_to, str
 
   reply: (user, strings...) ->
-    console.log "Replying"
     for str in strings
-      @send user, "@#{user.name} #{str}"
+      @send user, "@\"#{user.name}\" #{str}"
 
   run: ->
     self = @
@@ -21,7 +19,7 @@ class HipChat extends Robot
       name:     process.env.HUBOT_HIPCHAT_NAME or "#{self.name} Bot"
       password: process.env.HUBOT_HIPCHAT_PASSWORD
       rooms:    process.env.HUBOT_HIPCHAT_ROOMS or "@All"
-    
+
     console.log "Options:", @options
     bot = new Wobot(jid: @options.jid, name: @options.name, password: @options.password)
     mention = new RegExp("@#{@options.name.split(' ')[0]}\\b", "i")


### PR DESCRIPTION
"fully qualified" hipchat replies look like this: @"Fooby Barbot"
This means replies/mentions will go to the right person if you've got more than one user with the same first name.
