### PR TITLE
Hipchat adapter fix

### DIFF
--- a/src/adapters/hipchat.coffee
+++ b/src/adapters/hipchat.coffee
@@ -2,7 +2,7 @@ Robot        = require "../robot"
 HTTPS        = require "https"
 Wobot        = require("wobot").Bot
 
-class HipChat extends Robot
+class HipChat extends Robot.Adapter
   send: (user, strings...) ->
     for str in strings
       @bot.message user.reply_to, str


### PR DESCRIPTION
Can't use hubot with the hipchat adapter without this change. I'm guessing the other adapters that still inherit from Robot are broken as well.
