### PR TITLE
change XMPP adapter to also look for messages in the room when checking for self-messages

### DIFF
--- a/src/adapters/xmpp.coffee
+++ b/src/adapters/xmpp.coffee
@@ -88,6 +88,9 @@ class XmppBot extends Robot.Adapter
       message = body.getText()
 
       [room, from] = stanza.attrs.from.split '/'
+      
+      # ignore our own messages in rooms
+      return if from == @robot.username
 
       # note that 'from' isn't a full JID, just the local user part
       user = @userForId from


### PR DESCRIPTION
Chat messages from the bot will come from chatroom@server/username not username@server, so hubot responds to himself.
