### PR TITLE
Added punctuation to the alias too.

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -53,7 +53,7 @@ class Robot
     pattern = re.join("/") # combine the pattern back again
     if @alias
       alias = @alias.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&") # escape alias for regexp
-      newRegex = new RegExp("^(?:#{alias}|#{@name}[:,]?)\\s*(?:#{pattern})", modifiers)
+      newRegex = new RegExp("^(?:#{alias}[:,]?|#{@name}[:,]?)\\s*(?:#{pattern})", modifiers)
     else
       newRegex = new RegExp("^#{@name}[:,]?\\s*(?:#{pattern})", modifiers)
 


### PR DESCRIPTION
Before an alias called "megatron" couldn't be mentioned with a ":" or "," (e.g.: "MEGATRON: the rules") just without it. This change makes the alias work just like the "Hubot".
