### PR TITLE
If no name is given for the user, default to ID

### DIFF
--- a/src/user.coffee
+++ b/src/user.coffee
@@ -8,6 +8,7 @@ class User
   constructor: (@id, options = { }) ->
     for k of (options or { })
       @[k] = options[k]
+    @['name'] ||= @id
 
 module.exports = User
 

--- a/test/user_test.coffee
+++ b/test/user_test.coffee
@@ -1,0 +1,14 @@
+User = require '../src/user'
+assert = require 'assert'
+
+
+user = new User "Fake User", {name: 'fake', type: "groupchat"}
+assert.equal "Fake User", user.id
+assert.equal "groupchat", user.type
+assert.equal "fake", user.name
+
+user = new User "Fake User", {room: "chat@room.jabber", type: "groupchat"}
+assert.equal "Fake User", user.id
+assert.equal "chat@room.jabber", user.room
+assert.equal "groupchat", user.type
+assert.equal "Fake User", user.name # Make sure that if no name is given, we fallback to the ID


### PR DESCRIPTION
This is useful for XMPP where groupchat users only have an ID and not a
name.  Highlighted in issue #186.
