### PR TITLE
Hipchat adapter storage

### DIFF
--- a/src/adapters/third-party/hipchat.coffee
+++ b/src/adapters/third-party/hipchat.coffee
@@ -63,7 +63,6 @@ class HipChat extends Adapter
       author.name = from unless author.name
       author.reply_to = channel
       hubot_msg = message.replace(mention, "#{self.name}: ")
-      console.log "Author: ", author
       self.receive new Robot.TextMessage(author, hubot_msg)
 
     bot.onPrivateMessage (from, message) =>


### PR DESCRIPTION
Hipchat wasn't using the saved user so scripts like github-credentials did not save the data back to the brain.
