### PR TITLE
Proper user retrieval

### DIFF
--- a/src/adapters/third-party/hipchat.coffee
+++ b/src/adapters/third-party/hipchat.coffee
@@ -59,7 +59,8 @@ class HipChat extends Adapter
         console.log "Received error from HipChat:", message
 
     bot.onMessage (channel, from, message) ->
-      author = name: from, reply_to: channel
+      author = self.userForName from
+      author.reply_to = channel
       hubot_msg = message.replace(mention, "#{self.name}: ")
       self.receive new Robot.TextMessage(author, hubot_msg)
 


### PR DESCRIPTION
Each time the hipchat adpater receives a new message, a new user is instanciated so when other scripts modify its properties they aren't properly saved.
