### PR TITLE
Added reason of failure

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -147,6 +147,7 @@ class Robot
       @adapter = require("#{path}").use(@)
     catch err
       @logger.error "Cannot load adapter #{adapter}, try installing the package"
+      @logger.error "Reason: #{err}"
 
   # Public: Help Commands for Running Scripts
   #


### PR DESCRIPTION
It can fail for a number of reasons and is always important to know why, even to those who aren't directly developing hubot or its adapter to know if is the users fault or an error to report to developers.
