### PR TITLE
Redis server is needed for hubot shell as stated in github/hubot/#42

### DIFF
--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -9,7 +9,10 @@ Playing with Hubot
 ==================
 
 You'll need to install the necessary dependencies for hubot. All of
-those dependencies are provided by [npm](http://npmjs.org).
+those dependencies are provided by [npm](http://npmjs.org) except for       
+Redis server.    
+Ubuntu: ```sudo apt-get install redis-server```     
+Then:
 
     % bin/hubot
 


### PR DESCRIPTION
Had a connection refused error, googled, and found github/hubot/#42

Installing redis-server solved the issue.
