### PR TITLE
check instance in TextListener via constructor.name

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -297,7 +297,7 @@ class TextListener extends Listener
   # callback - The Function that is triggered if the incoming message matches.
   constructor: (@robot, @regex, @callback) ->
     @matcher = (message) =>
-      if message instanceof Robot.TextMessage
+      if message.constructor.name is "TextMessage"
         message.match @regex
 
 class Robot.Response


### PR DESCRIPTION
This fixes a problem which I encountered in hubot-irc (related issue
nandub/hubot-irc#2). I guess the problem is that the Robot.TextMessage object
is created in a different module and therefore the `instanceof` call fails
although it is technically a proper instance. However checking the instance
via the `constructor.name` property works.

I'm pretty new to coffee-script, so there is maybe a better way to solve this directly in the adapter module. After all, the other adapters don't seem to have this problem. But I couldn't figure out what they do differently.
