### PR TITLE
Fix tests passing by accident.

### DIFF
--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -22,7 +22,7 @@ exports.danger = (helper, cb) ->
 
   server.start = (tests, cb) ->
     server.listen 9001, ->
-      helper.cb = (messages...) ->
+      helper.adapter.cb = (messages...) ->
         tests.shift() messages...
         server.close() if tests.length == 0
 


### PR DESCRIPTION
Currently the tests are passing by accident.  The callbacks in a test files `tests` array are never actually called as the `.cb` property is on the adapter, not the bot itself.

An alternative to this is to use `@robot.cb?` in `Danger#send()`
