### PR TITLE
Don't fail noisily when a user is not found

### DIFF
--- a/src/scripts/roles.coffee
+++ b/src/scripts/roles.coffee
@@ -55,8 +55,6 @@ module.exports = (robot) ->
               msg.send "Ok, #{name} is #{newRole}."
         else if users.length > 1
           msg.send getAmbiguousUserText users
-        else
-          msg.send "I don't know anything about #{name}."
 
   robot.respond /([\w .-_]+) is not (["'\w: -_]+)[.!]*$/i, (msg) ->
     name    = msg.match[1]
@@ -75,6 +73,4 @@ module.exports = (robot) ->
           msg.send "Ok, #{name} is no longer #{newRole}."
       else if users.length > 1
         msg.send getAmbiguousUserText users
-      else
-        msg.send "I don't know anything about #{name}."
 


### PR DESCRIPTION
The roles script tends to fire frequently on unrelated commands (for ex., "hubot, the rent is too damn high"). With an error message for users who aren't found, Hubot ends up babbling a lot, in ways that make me doubt his intelligence. I'm just removing the error reporting here - hopefully that's good enough since there's always a reply on success.
