### PR TITLE
make role.coffee script honor the hipchat @ syntax

### DIFF
--- a/src/scripts/roles.coffee
+++ b/src/scripts/roles.coffee
@@ -13,7 +13,7 @@ module.exports = (robot) ->
   getAmbiguousUserText = (users) ->
     "Be more specific, I know #{users.length} people named like that: #{(user.name for user in users).join(", ")}"
 
-  robot.respond /who is ([\w .-]+)\?*$/i, (msg) ->
+  robot.respond /who is @?([\w .-]+)\?*$/i, (msg) ->
     name = msg.match[1]
 
     if name is "you"
@@ -34,7 +34,7 @@ module.exports = (robot) ->
       else
         msg.send "#{name}? Never heard of 'em"
 
-  robot.respond /([\w .-_]+) is (["'\w: -_]+)[.!]*$/i, (msg) ->
+  robot.respond /@?([\w .-_]+) is (["'\w: -_]+)[.!]*$/i, (msg) ->
     name    = msg.match[1]
     newRole = msg.match[2].trim()
 
@@ -58,7 +58,7 @@ module.exports = (robot) ->
         else
           msg.send "I don't know anything about #{name}."
 
-  robot.respond /([\w .-_]+) is not (["'\w: -_]+)[.!]*$/i, (msg) ->
+  robot.respond /@?([\w .-_]+) is not (["'\w: -_]+)[.!]*$/i, (msg) ->
     name    = msg.match[1]
     newRole = msg.match[2].trim()
 


### PR DESCRIPTION
In HipChat if you prefix a username with an '@' symbol it directs a notification at that user.  It's fun to notify a user of their pending role change using this mechanism.

This change makes that @ symbol optional.
