### PR TITLE
Set User-Agent header on translate calls

### DIFF
--- a/src/scripts/translate.coffee
+++ b/src/scripts/translate.coffee
@@ -83,6 +83,7 @@ module.exports = (robot) ->
         uptl: "en"
         text: term
       })
+      .header('User-Agent', 'Mozilla/5.0')
       .get() (err, res, body) ->
         data   = body
         if data.length > 4 && data[0] == '['


### PR DESCRIPTION
This is required for certain language translations such as `Наконец-то, я`
### Previous response

```
Hubot> hubot translate Наконец-то, я
Hubot> "Наконец-то, я" is Spanish for "� � � � � d � � � �μ� �- �, � � �"
```
### New Response

```
Hubot> hubot translate Наконец-то, я
Hubot> "Наконец-то, я" is Russian for "Finally , I am"
```
