### PR TITLE
Add a catch-all listener

### DIFF
--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -7,7 +7,7 @@ server = require('http').createServer (req, res) ->
   res.end "fetched"
 
 server.listen 9001, ->
-  assert.equal 4, helper.listeners.length
+  assert.equal 5, helper.listeners.length
   assert.equal 0, helper.sent.length
 
   helper.adapter.receive 'test'
@@ -22,6 +22,7 @@ server.listen 9001, ->
   assert.equal 3, helper.sent.length
   assert.ok helper.sent[2].match(/^(1|2)$/)
 
+
   # Test that when we message a room, the 'recipient' is the robot user and the room attribute is set properly
   helper.messageRoom "chat@example.com", "Hello room"
   assert.equal 4, helper.sent.length
@@ -29,9 +30,14 @@ server.listen 9001, ->
   assert.equal helper.id, helper.recipients[3].id
   assert.equal "Hello room", helper.sent[3]
 
+  helper.adapter.receive 'foobar'
+  assert.equal 5, helper.sent.length
+  assert.equal 'catch-all', helper.sent[4]
+
+
   # set a callback for when the next message is replied to
   helper.cb = (msg) ->
-    assert.equal 5, helper.sent.length
+    assert.equal 6, helper.sent.length
     assert.equal 'fetched', msg
     helper.close()
     server.close()

--- a/test/scripts/test.coffee
+++ b/test/scripts/test.coffee
@@ -16,3 +16,5 @@ module.exports = (robot) ->
       .get() (err, res, body) ->
         msg.send body
 
+  robot.catchall (msg) ->
+    msg.send 'catch-all' if msg.message.text is 'foobar'

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -57,8 +57,11 @@ class Danger extends Adapter
     @send user, "#{@robot.name}: #{str}" for str in strings
 
   receive: (text) ->
-    user = new User 1, 'helper'
-    super new Robot.TextMessage user, text
+    if typeof text is 'string'
+      user = new User 1, 'helper'
+      super new Robot.TextMessage user, text
+    else
+      super text
 
 if not process.env.HUBOT_LIVE
   class Helper.Response extends Robot.Response


### PR DESCRIPTION
Requested by @neilcauldwell

Adds a new `robot.catchall` listener that only triggers when no other listeners match.

Note: It seems like the hubot build is currently broken, and I didn't have time to fix it, but this patch was passing before master broke.
