### PR TITLE
Self is not defined in shell script.

### DIFF
--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -15,6 +15,7 @@ class Shell extends Adapter
     @send user, strings...
 
   run: ->
+    self = @
     stdin = process.openStdin()
     stdout = process.stdout
 


### PR DESCRIPTION
The shell version of hubot does not have the variable self set. Thus it throws the following error:

```
# bin/hubot -a shell -n a
ReferenceError: self is not defined
  at Shell.run (/opt/hubot/src/adapters/shell.coffee:68:7)
  at Robot.run (/opt/hubot/src/robot.coffee:297:27)
  at Object.<anonymous> (/opt/hubot/bin/hubot:111:11)
  at Object.<anonymous> (/opt/hubot/bin/hubot:114:4)
  at Module._compile (module.js:441:26)
  at Object.run (/usr/lib/node_modules/coffee-script/lib/coffee-script/coffee-s
  at /usr/lib/node_modules/coffee-script/lib/coffee-script/command.js:135:29
  at /usr/lib/node_modules/coffee-script/lib/coffee-script/command.js:110:18
  at [object Object].<anonymous> (fs.js:115:5)
  at [object Object].emit (events.js:64:17)
```
