### PR TITLE
If Hubot is run with a different name, help displays the instance name.

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -10,5 +10,7 @@ module.exports = (robot) ->
     cmds = robot.helpCommands()
     if msg.match[1]
       cmds = cmds.filter (cmd) -> cmd.match(new RegExp(msg.match[1]))
-    msg.send cmds.join("\n")
-
+    emit = cmds.join("\n")
+    unless robot.name is 'Hubot'
+      emit = emit.replace(/(H|h)ubot/g, robot.name)
+    msg.send emit


### PR DESCRIPTION
when running Hubot under a different name, it is nice to have the help output not mention Hubot by name
