### PR TITLE
As hubot is frequently used in business settings, turn safe search on

### DIFF
--- a/src/scripts/google-images.coffee
+++ b/src/scripts/google-images.coffee
@@ -29,7 +29,7 @@ module.exports = (robot) ->
 
 imageMe = (msg, query, cb) ->
   msg.http('http://ajax.googleapis.com/ajax/services/search/images')
-    .query(v: "1.0", rsz: '8', q: query)
+    .query(v: "1.0", rsz: '8', q: query, safe: 'active')
     .get() (err, res, body) ->
       images = JSON.parse(body)
       images = images.responseData.results


### PR DESCRIPTION
We've had a couple of minor problems using hubot in the office since some non-safe images can still get through on moderate (usually bikini-type pictures).  These are a bit hostile to a welcoming office environment, so I'd love safe search to be the default out of the box.  People can modify it if they want to, but this is probably a reasonable default.
