### PR TITLE
Don't try to add or remove roles for empty names

### DIFF
--- a/src/scripts/roles.coffee
+++ b/src/scripts/roles.coffee
@@ -35,7 +35,7 @@ module.exports = (robot) ->
         msg.send "#{name}? Never heard of 'em"
 
   robot.respond /@?([\w .-_]+) is (["'\w: -_]+)[.!]*$/i, (msg) ->
-    name    = msg.match[1]
+    name    = msg.match[1].trim()
     newRole = msg.match[2].trim()
 
     unless name in ['', 'who', 'what', 'where', 'when', 'why']
@@ -59,10 +59,10 @@ module.exports = (robot) ->
           msg.send "I don't know anything about #{name}."
 
   robot.respond /@?([\w .-_]+) is not (["'\w: -_]+)[.!]*$/i, (msg) ->
-    name    = msg.match[1]
+    name    = msg.match[1].trim()
     newRole = msg.match[2].trim()
 
-    unless name in ['who', 'what', 'where', 'when', 'why']
+    unless name in ['', 'who', 'what', 'where', 'when', 'why']
       users = robot.usersForFuzzyName(name)
       if users.length is 1
         user = users[0]


### PR DESCRIPTION
Fixes a bug where a message of the type "@hubot is that cool?" would result in a response of "I don't know anything about ."

This came up because we have another script that responds to questions like "is [something something]?" with yes-or-no answers.
