### PR TITLE
Fix SyntaxError in Shell adapter under CoffeeScript 1.3.x

### DIFF
--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -6,7 +6,7 @@ Adapter  = require '../adapter'
 class Shell extends Adapter
   send: (user, strings...) ->
     unless process.platform is "win32"
-      console.log "\033[01;32m#{str}\033[0m" for str in strings
+      console.log "\x1b[01;32m#{str}\x1b[0m" for str in strings
     else
       console.log "#{str}" for str in strings
     @repl.prompt()


### PR DESCRIPTION
CoffeeScript version was upgraded from 1.2.0 to 1.3.1 in 8269f5a, this fixes a SyntaxError caused by 1.3.x's new strict checks.

More info: https://github.com/jashkenas/coffee-script/issues/1547
