### PR TITLE
Two fixes to the new HEROKU_URL option

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -193,12 +193,12 @@ class Robot
 
     @connect.listen process.env.PORT || 8080
 
-    hostname = process.env.HEROKU_URL
+    herokuUrl = process.env.HEROKU_URL
 
-    if hostname
-      hostname += '/' unless /\/$/.test hostname
+    if herokuUrl
+      herokuUrl += '/' unless /\/$/.test herokuUrl
       setInterval =>
-        HttpClient.create("#{hostname}hubot/ping")
+        HttpClient.create("#{herokuUrl}hubot/ping")
           .post() (err, res, body) =>
             @logger.info "keep alive ping!"
       , 1200000


### PR DESCRIPTION
- When the `HEROKU_URL` environment variable was not set the keep alive code would still run trying to connect to: `undefined//hubot/ping`
- Keep-alive request path started with a slash, combined with the trailing slash check, this would create a keep-alive request to: `http://appname.herokuapp.com//hubot/ping`

I've tested these changes to ensure they work, and my own IRC bot is currently running off of the `heroku-url-fix` branch.

/cc @tombell
