### PR TITLE
Fix BasicAuth for internal HTTP server

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -170,7 +170,7 @@ class Robot
 
     @connect = Connect()
 
-    @connect.use Connect.basicAuth(user, path) if user and pass
+    @connect.use Connect.basicAuth(user, pass) if user and pass
     @connect.use Connect.bodyParser()
     @connect.use Connect.router (app) =>
 


### PR DESCRIPTION
When using the `CONNECT_USER` and `CONNECT_PASSWORD` environment variables, the following error was being raised:

```
ReferenceError: path is not defined
```
