### PR TITLE
Fix repository URL in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   }],
 
   "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/github/hubot.git"
+    "type": "git",
+    "url":  "https://github.com/github/hubot.git"
   },
 
   "dependencies": {

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -10,8 +10,8 @@
   }],
 
   "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/github/hubot.git"
+    "type": "git",
+    "url":  "https://github.com/github/hubot.git"
   },
 
   "dependencies": {


### PR DESCRIPTION
I'm not fully sure how important it is to have `https` rather `http` in the repo URL, as the [NPM Registry](http://search.npmjs.org/#/hubot) the repo URL is listed as `git://github.com/github/hubot.git`. But can't hurt right? :)

Additionally, I also brought a little bit more consistency to the general formatting of the package.json files.
