### PR TITLE
Make sure the undefined user has the correct room set before returning a user object.

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -277,7 +277,7 @@ class Robot
       user = new User id, options
       @brain.data.users[id] = user
 
-    if options.room and user.room isnt options.room
+    if options.room and (!user.room or user.room isnt options.room)
       user = new User id, options
       @brain.data.users[id] = user
 


### PR DESCRIPTION
I experienced this issue with hubot-irc, but here's steps to reproduce the problem:
- Join the bot to two or more rooms
- Invoke messageRoom
- Obserer that the message is sent to the correct room
- Invoke messageRoom again with a different room
- Observe that the message is sent to the first room, not the second.

This is happening because the undefined user object in brain.data.users got set with the first room, then this version is returned without checking that the rooms actually match.

There are probably other ways of dealing with this (i.e. [https://github.com/github/hubot/issues/234#issuecomment-3809099]), but I'd like to at least open the discussion on this.
