### PR TITLE
Additional message room fix

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -277,7 +277,7 @@ class Robot
       user = new User id, options
       @brain.data.users[id] = user
 
-    if options.room and (!user.room or user.room isnt options.room)
+    if options and options.room and (!user.room or user.room isnt options.room)
       user = new User id, options
       @brain.data.users[id] = user
 


### PR DESCRIPTION
This relates to #282, when the bot encounters a new user for the first time (or a user with a changed nick) no options are passed in and thus the check on line 280 was failing.
