### PR TITLE
Improve help output by including robot name

### DIFF
--- a/src/scripts/google-images.coffee
+++ b/src/scripts/google-images.coffee
@@ -1,12 +1,9 @@
 # A way to interact with the Google Images API.
 #
-# image me <query>    - The Original. Queries Google Images for <query> and
-#                       returns a random top result.
-# animate me <query>  - The same thing as `image me`, except adds a few
-#                       parameters to try to return an animated GIF instead.
-# mustache me <url>   - Adds a mustache to the specified URL.
-# mustache me <query> - Searches Google Images for the specified query and
-#                       mustaches it.
+# hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
+# hubot animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
+# hubot mustache me <url> - Adds a mustache to the specified URL.
+# hubot mustache me <query> - Searches Google Images for the specified query and mustaches it.
 module.exports = (robot) ->
   robot.respond /(image|img)( me)? (.*)/i, (msg) ->
     imageMe msg, msg.match[3], (url) ->

--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -2,8 +2,8 @@
 #
 # These commands are grabbed from comment blocks at the top of each file.
 #
-# help - Displays all of the help commands that Hubot knows about.
-# help <query> - Displays all help commands that match <query>.
+# hubot help - Displays all of the help commands that Hubot knows about.
+# hubot help <query> - Displays all help commands that match <query>.
 
 module.exports = (robot) ->
   robot.respond /help\s*(.*)?$/i, (msg) ->

--- a/src/scripts/maps.coffee
+++ b/src/scripts/maps.coffee
@@ -1,6 +1,6 @@
 # Interacts with the Google Maps API.
 #
-# map me <query> - Returns a map view of the area returned by `query`.
+# hubot map me <query> - Returns a map view of the area returned by `query`.
 
 module.exports = (robot) ->
 

--- a/src/scripts/math.coffee
+++ b/src/scripts/math.coffee
@@ -1,7 +1,7 @@
 # Allows Hubot to do mathematics.
 #
-# math me <expression> - Calculate the given expression.
-# convert me <expression> to <units> - Convert expression to given units.
+# hubot math me <expression> - Calculate the given expression.
+# hubot convert me <expression> to <units> - Convert expression to given units.
 module.exports = (robot) ->
   robot.respond /(calc|calculate|convert|math)( me)? (.*)/i, (msg) ->
     msg

--- a/src/scripts/pugme.coffee
+++ b/src/scripts/pugme.coffee
@@ -1,7 +1,7 @@
 # Pugme is the most important thing in your life
 #
-# pug me - Receive a pug
-# pug bomb N - get N pugs
+# hubot pug me - Receive a pug
+# hubot pug bomb N - get N pugs
 
 module.exports = (robot) ->
 

--- a/src/scripts/roles.coffee
+++ b/src/scripts/roles.coffee
@@ -1,8 +1,8 @@
 # Assign roles to people you're chatting with
 #
-# <user> is a badass guitarist - assign a role to a user
-# <user> is not a badass guitarist - remove a role from a user
-# who is <user> - see what roles a user has
+# hubot <user> is a badass guitarist - assign a role to a user
+# hubot <user> is not a badass guitarist - remove a role from a user
+# hubot who is <user> - see what roles a user has
 
 # hubot holman is an ego surfer
 # hubot holman is not an ego surfer

--- a/src/scripts/rules.coffee
+++ b/src/scripts/rules.coffee
@@ -14,7 +14,7 @@ otherRules = [
 
 # Make sure that hubot knows the rules.
 #
-# the rules - Make sure hubot still knows the rules.
+# hubot the rules - Make sure hubot still knows the rules.
 module.exports = (robot) ->
   robot.respond /(what are )?the (three |3 )?(rules|laws)/i, (msg) ->
     text = msg.message.text

--- a/src/scripts/storage.coffee
+++ b/src/scripts/storage.coffee
@@ -1,7 +1,7 @@
 # Inspect the data in redis easily
 #
-# show users - Display all users that hubot knows about
-# show storage - Display the contents that are persisted in redis
+# hubot show users - Display all users that hubot knows about
+# hubot show storage - Display the contents that are persisted in redis
 #
 
 Util = require "util"

--- a/src/scripts/translate.coffee
+++ b/src/scripts/translate.coffee
@@ -1,9 +1,7 @@
 # Allows Hubot to know many languages.
 #
-# translate me <phrase> - Searches for a translation for the <phrase> and then
-#                         prints that bad boy out.
-#
-# translate me from <source> into <target> <phrase> - Translates <phrase> from <source> into <target>. Both <source> and <target> are optional
+# hubot translate me <phrase> - Searches for a translation for the <phrase> and then prints that bad boy out.
+# hubot translate me from <source> into <target> <phrase> - Translates <phrase> from <source> into <target>. Both <source> and <target> are optional
 #
 
 languages =

--- a/src/scripts/youtube.coffee
+++ b/src/scripts/youtube.coffee
@@ -1,7 +1,6 @@
 # Messing around with the YouTube API.
 #
-# youtube me <query> - Searches YouTube for the query and returns the video
-#                      embed link.
+# hubot youtube me <query> - Searches YouTube for the query and returns the video embed link.
 module.exports = (robot) ->
   robot.respond /(youtube|yt)( me)? (.*)/i, (msg) ->
     query = msg.match[3]


### PR DESCRIPTION
Most help commands look like this:

```
mustache me <url>   - Adds a mustache to the specified URL.
```

A new user to Hubot might know enough to ask him for 'help', but once
they get this, they would likely just type 'mustache me ...' without
addressing Hubot.

This would not work, since it uses 'respond', not hear, but you wouldn't
know that from this help, without reading the source.

help.coffee has even had support for replacing the 'Hubot' in the help with
running robot's name since 57f5f098d1414663f85f93af7f20f9cae1b90018.

This commit updates all the default scripts to include a 'hubot' prefix
when it makes sense.

In addition, it updates the formatting of the help:
- only use one line (second line would be cut off)
- don't pad - to match other help (sorting wouldn't guarantee them
  to be grouped together)
