### PR TITLE
Improve error logging with stack traces

### DIFF
--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -169,8 +169,8 @@ class CampfireStreaming extends EventEmitter
                 try
                   data = JSON.parse part
                   self.emit data.type, data.id, data.created_at, data.room_id, data.user_id, data.body
-                catch err
-                  logger.error "Campfire error: #{err}"
+                catch error
+                  logger.error "Campfire error: #{error}\n#{error.stack}"
 
         response.on "end", ->
           logger.error "Streaming connection closed for room #{id}. :("
@@ -235,7 +235,7 @@ class CampfireStreaming extends EventEmitter
 
         try
           callback null, JSON.parse(data)
-        catch err
+        catch error
           callback null, data or { }
 
       response.on "error", (err) ->

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -115,8 +115,8 @@ class Robot
       try
         results.push listener.call(message)
         break if message.done
-      catch ex
-        @logger.error "Unable to call the listener: #{ex}"
+      catch error
+        @logger.error "Unable to call the listener: #{error}\n#{error.stack}"
         false
     if message not instanceof Robot.CatchAllMessage and results.indexOf(true) is -1
       @receive new Robot.CatchAllMessage(message)
@@ -149,8 +149,8 @@ class Robot
       try
         require(full) @
         @parseHelp "#{path}/#{file}"
-      catch err
-        @logger.error "#{err}"
+      catch error
+        @logger.error "Unable to load #{path}: #{error}\n#{error.stack}"
 
   loadHubotScripts: (path, scripts) ->
     @logger.info "Loading hubot-scripts from #{path}"
@@ -220,7 +220,7 @@ class Robot
 
       @adapter = require("#{path}").use(@)
     catch err
-      @logger.error "Cannot load adapter #{adapter} - #{err}"
+      @logger.error "Cannot load adapter #{adapter} - #{err}\n#{err.stack}"
 
   # Public: Help Commands for Running Scripts
   #


### PR DESCRIPTION
Prior to, errors encountered only logged the type and message, but
didn't include a stack trace. This can be very frustrating when
debugging, particularly when just starting to use hubot.

Stack traces are our friends :)

And since we're in the neighborhood, also update to use a
consistent variable for the error object.
