### PR TITLE
Reduce log output during normal startup

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -128,7 +128,7 @@ class Robot
   #
   # Returns nothing.
   load: (path) ->
-    @logger.info "Loading scripts from #{path}"
+    @logger.debug "Loading scripts from #{path}"
 
     Path.exists path, (exists) =>
       if exists


### PR DESCRIPTION
Robot.load does `@logger.info when` loading scripts from directories. It's
not really that useful of information unless you doing debugging, hence
`@logger.debug` makes sense.
