### PR TITLE
Superify the help output

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -244,9 +244,9 @@ class Robot
     Fs.readFile path, 'utf-8', (err, body) =>
       throw err if err?
       for i, line of body.split("\n")
-        break    if !(line[0] == '#' or line.substr(0, 2) == '//')
-        continue if !line.match('-')
-        @commands.push line[2..line.length]
+        break    if not (line[0] == '#' or line.substr(0, 2) == '//')
+        continue if not line.match('-')
+        @commands.push line[2..line.length].replace /^hubot/i, @name
 
   # Public: A helper send function which delegates to the adapter's send
   # function.


### PR DESCRIPTION
You should now document `robot.respond` commands with hubot at the beginning. This will get replaced in the help output so the correct name of the running robot is displayed.
### Example

``` coffeescript

# hubot good morning - responds with a good morning greeting
# poopin - responds with a poopin'

module.exports = (robot) ->

  robot.respond /good morning/i, (msg) ->
    msg.reply 'Good morning'

  robot.hear /poopin/i, (msg) ->
    msg.send 'Poopin'
```

Run the hubot instance with `bin/hubot -n poopbot` and doing `poopbot help` would respond with the following.

```
...
poopbot good morning - responds with a good morning greeting
poopin - responds with a poopin'
...
```

This solves the whaa whaa about using `hubot` in the help header comments. Just remember the comments should be `hubot` to document respond commands. :)
