### PR TITLE
Correct the logger.error output when loadFile fails

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -152,7 +152,7 @@ class Robot
         require(full) @
         @parseHelp "#{path}/#{file}"
       catch error
-        @logger.error "Unable to load #{path}: #{error}\n#{error.stack}"
+        @logger.error "Unable to load #{full}: #{error}\n#{error.stack}"
 
   # Public: Load scripts specfic in the `hubot-scripts.json` file.
   #


### PR DESCRIPTION
It was `Unable to load #{path}`, but `path` is a directory, not the
full path to the file. It should be `full` to get directory & filename.
