### PR TITLE
Reduce log output during normal startup (redux)

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -161,7 +161,7 @@ class Robot
   #
   # Returns nothing.
   loadHubotScripts: (path, scripts) ->
-    @logger.info "Loading hubot-scripts from #{path}"
+    @logger.debug "Loading hubot-scripts from #{path}"
     for script in scripts
       @loadFile path, script
 


### PR DESCRIPTION
My pull request for eacfeaaddda2ba89bbf8cb521620b44ac95ed2b7 updated
load to use logger.info. This does the same for loadHubotScripts :)
