### PR TITLE
Fix parse error (typo) in src/creator.coffee

### DIFF
--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -17,7 +17,7 @@ class Creator
   mkdirDashP: (path) ->
     Path.exists path, (exists) ->
       unless exists
-        Fs.mkdir path, 0o0755, (err) ->
+        Fs.mkdir path, 0x0755, (err) ->
           throw err if err
 
   # Copy the contents of a file from one place to another.


### PR DESCRIPTION
```
 $ bin/hubot
Error: In /home/steven/github/hubot/src/creator.coffee, Parse error on line 20: Unexpected 'IDENTIFIER'
```
