### PR TITLE
Improve Animate Me by Always Replying With gifs 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "scoped-http-client": "0.9.7",
     "log": "1.3.0",
     "connect": "2.1.0",
-    "connect_router": "1.8.6"
+    "connect_router": "1.8.6",
+    "underscore": "1.3.3"
   },
 
   "main": "./index",

--- a/src/scripts/google-images.coffee
+++ b/src/scripts/google-images.coffee
@@ -4,13 +4,16 @@
 # hubot animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
 # hubot mustache me <url> - Adds a mustache to the specified URL.
 # hubot mustache me <query> - Searches Google Images for the specified query and mustaches it.
+
+_ = require('underscore')._
+
 module.exports = (robot) ->
   robot.respond /(image|img)( me)? (.*)/i, (msg) ->
     imageMe msg, msg.match[3], (url) ->
       msg.send url
 
   robot.respond /animate me (.*)/i, (msg) ->
-    imageMe msg, "animated #{msg.match[1]}", (url) ->
+    imageMe msg, msg.match[1], as_filetype: "gif", (url) ->
       msg.send url
 
   robot.respond /(?:mo?u)?sta(?:s|c)he?(?: me)? (.*)/i, (msg) ->
@@ -24,9 +27,10 @@ module.exports = (robot) ->
       imageMe msg, imagery, (url) ->
         msg.send "#{mustachify}#{url}"
 
-imageMe = (msg, query, cb) ->
+imageMe = (msg, query, queryOptions, cb) ->
+  cb = queryOptions if typeof queryOptions == 'function' 
   msg.http('http://ajax.googleapis.com/ajax/services/search/images')
-    .query(v: "1.0", rsz: '8', q: query, safe: 'active')
+    .query(_.extend({v: "1.0", rsz: '8', q: query, safe: 'active'}, queryOptions ? {}))
     .get() (err, res, body) ->
       images = JSON.parse(body)
       images = images.responseData.results


### PR DESCRIPTION
Hey,

Currently `animate me` returns poor results since the current query just prepends "animated" and relies on that returning animated pics/gifs but succeeds probably less than half the time.

I've fixed this by explicitly querying for gif filetypes and the results are much better and funner!

Thanks!

Travis
