### PR TITLE
Fix for bug with Hubot sending messages to the wrong room

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -265,7 +265,7 @@ class Robot
   #
   # Returns nothing.
   messageRoom: (room, strings...) ->
-    user = @userForId @id, { room: room }
+    user = { room: room }
     @adapter.send user, strings...
 
   # Public: A helper reply function which delegates to the adapter's reply

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -28,17 +28,22 @@ server.listen 9001, ->
   helper.messageRoom "chat@example.com", "Hello room"
   assert.equal 4, helper.sent.length
   assert.equal "chat@example.com", helper.recipients[3].room
-  assert.equal helper.id, helper.recipients[3].id
   assert.equal "Hello room", helper.sent[3]
 
-  helper.adapter.receive 'foobar'
+  helper.messageRoom "chat2@example.com", "Hello to another room"
   assert.equal 5, helper.sent.length
-  assert.equal 'catch-all', helper.sent[4]
+  assert.equal "chat2@example.com", helper.recipients[4].room
+  assert.equal "Hello to another room", helper.sent[4]
+
+
+  helper.adapter.receive 'foobar'
+  assert.equal 6, helper.sent.length
+  assert.equal 'catch-all', helper.sent[5]
 
 
   # set a callback for when the next message is replied to
   helper.cb = (msg) ->
-    assert.equal 6, helper.sent.length
+    assert.equal 7, helper.sent.length
     assert.equal 'fetched', msg
     helper.close()
     server.close()


### PR DESCRIPTION
This fixes an issue identified in #275 where if Hubot joined multiple rooms, userForId
would return the user object with the room attribute from the first
message as persisted by Redis so the each subsequent message would always get sent to the room from the first message.

Since the adapter only cares about the room the user belongs to, we can
just construct an object that provides that information rather than
polluting robot.brain with a fake user object via userForId

Tested this with XMPP, Campfire and IRC adapters.
