### PR TITLE
Add route for knowing the IP where the bot is host

### DIFF
--- a/src/scripts/httpd.coffee
+++ b/src/scripts/httpd.coffee
@@ -15,6 +15,7 @@
 #   /hubot/ping
 #   /hubot/time
 #   /hubot/info
+#   /hubot/ip
 
 spawn = require('child_process').spawn
 
@@ -35,3 +36,7 @@ module.exports = (robot) ->
     child.stdout.on 'data', (data) ->
       res.end "#{data.toString().trim()} running node #{process.version} [pid: #{process.pid}]"
       child.stdin.end()
+
+  robot.router.get "/hubot/ip", (req, res) ->
+    robot.http('http://checkip.dyndns.org').get() (err, r, body) ->
+      res.end body


### PR DESCRIPTION
Useful if you have the bot on the cloud and it gets banned from IRC. You need to know the IP from where it connects in order to ask for an unban.  
