### PR TITLE
Loading stock scripts from .. relative path

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -90,6 +90,9 @@ else
     scriptsPath = Path.resolve ".", "scripts"
     robot.load scriptsPath
 
+    scriptsPath = Path.resolve "..", "scripts"
+    robot.load scriptsPath
+
     scriptsPath = Path.resolve "src", "scripts"
     robot.load scriptsPath
 


### PR DESCRIPTION
Our hubot install uses the following bash script during boot-up
to auto-update our install.

However, hubot itself will not find scripts like help.coffee unless
the script finding code here is updated.
# !/bin/sh

export HUBOT_DIR='/opt/hubot/'
export ADAPTER='hipchat'
export HUBOT_USER='lighthouse'
export PORT='5555'

export PATH="${HUBOT_DIR}node_modules/.bin:${HUBOT_DIR}node_modules/hubot/node_modules/.bin:$PATH"

cd ${HUBOT_DIR}
hg pull -u https://somerepo.com
npm update
exec node_modules/hubot/bin/hubot --name ${HUBOT_USER} --adapter ${ADAPTER} --alias '/'
