### PR TITLE
Properly load hubot-scripts with NPM Hubot install

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -75,7 +75,7 @@ if Options.create
   creator.run()
 
 else
-  adapterPath = Path.resolve __dirname, "..", "src", "adapters"
+  adapterPath = Path.join __dirname, "..", "src", "adapters"
 
   robot = Hubot.loadBot adapterPath, Options.adapter, Options.enableHttpd, Options.name
 
@@ -87,21 +87,27 @@ else
   robot.alias = Options.alias
 
   loadScripts = ->
-    scriptsPath = Path.resolve ".", "scripts"
+    scriptsPath = Path.join __dirname, "..", "scripts"
     robot.load scriptsPath
 
-    scriptsPath = Path.resolve "src", "scripts"
+    scriptsPath = Path.join __dirname, "..", "src", "scripts"
     robot.load scriptsPath
 
-    scriptsFile = Path.resolve "hubot-scripts.json"
+    scriptsFile = Path.join __dirname, "..", "hubot-scripts.json"
+    if not Fs.existsSync scriptsFile
+      scriptsFile = Path.join __dirname, "..", "..", "..", "hubot-scripts.json"
+
+    scriptsPath = Path.join __dirname, "node_modules", "hubot-scripts", "src", "scripts"
+    if not Fs.existsSync scriptsPath
+      scriptsPath = Path.join __dirname, "..", "..", "hubot-scripts", "src", "scripts"
+
     Path.exists scriptsFile, (exists) =>
       if exists
         Fs.readFile scriptsFile, (err, data) ->
           scripts = JSON.parse data
-          scriptsPath = Path.resolve "node_modules", "hubot-scripts", "src", "scripts"
           robot.loadHubotScripts scriptsPath, scripts
 
   robot.adapter.on 'connected', loadScripts
 
   robot.run()
-
+  


### PR DESCRIPTION
This builds on a prior __dirname patch from @keithduncan

https://github.com/github/hubot/pull/334
That pull should be made first

When Hubot is installed from NPM, the relative path of
../hubot-scripts.json is no longer valid

An npm install looks like

myhubot
  node_modules
    hubot
      bin
        hubot
    hubot-scripts
      src
        scripts
  hubot-scripts.json

Thefore the original paths specified here are not correct.  We don't
run on Heroku, so the original path resolutions are left intact, with
fallbacks to the NPM style install if things don't exist.

Opted for sync Fs API here since this is an initial load and won't
hurt perf.
