### PR TITLE
Help command should only escape help when it's on a HTML-Adapter

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -52,7 +52,7 @@ helpContents = (name, commands) ->
 
 module.exports = (robot) ->
   robot.respond /help\s*(.*)?$/i, (msg) ->
-    cmds = robot.helpCommands().map (cmd) ->
+    cmds = if process.env.HUBOT_ESCAPE_HELP is 'false' then robot.helpCommands() else robot.helpCommands().map (cmd) ->
       cmd.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
 
     if msg.match[1]


### PR DESCRIPTION
Hey there,

to ensure that the help messages are only escaped when necessary I added a new environment variable "HUBOT_ESCAPE_HELP" which should be a string 'true' or 'false' due to the lack of boolean environment variables.

Default is not escaped, b/c most of the available adapters are not html-aware.

Love,
