### PR TITLE
Option to specify extra scripts dirs

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -22,6 +22,7 @@ Switches = [
   [ "-h", "--help",            "Display the help information" ],
   [ "-l", "--alias ALIAS",     "Enable replacing the robot's name with alias" ],
   [ "-n", "--name NAME",       "The name of the robot in chat" ],
+  [ "-r", "--scripts PATH",    "Alternative scripts path" ],
   [ "-s", "--enable-slash",    "Enable replacing the robot's name with '/' (deprecated)" ],
   [ "-v", "--version",         "Displays the version of hubot installed" ]
 ]
@@ -31,6 +32,7 @@ Options =
   alias: false
   create: false
   enableHttpd: true
+  scripts: []
   name: "Hubot"
   path: "."
 
@@ -56,6 +58,9 @@ Parser.on "alias", (opt, value) ->
 
 Parser.on "name", (opt, value) ->
   Options.name = value
+
+Parser.on "scripts", (opt, value) ->
+  Options.scripts.push(value)
 
 Parser.on "enable-slash", (opt) ->
   console.log "WARNING: -s and --enable-slash are deprecated please use -l or --alias '/'"
@@ -100,6 +105,13 @@ else
           scripts = JSON.parse data
           scriptsPath = Path.resolve "node_modules", "hubot-scripts", "src", "scripts"
           robot.loadHubotScripts scriptsPath, scripts
+
+    for path in Options.scripts
+      if path[0] == '/'
+        scriptsPath = path
+      else
+        scriptsPath = Path.resolve ".", path
+      robot.load scriptsPath
 
   robot.adapter.on 'connected', loadScripts
 


### PR DESCRIPTION
Hello,

I added an option to specify extra scripts dirs to load.  It's useful for us because we have a lot of scripts that are specific to our company and reside in our git repo.  It would be nice to run Hubot and just point it at this dir, that way we can upgrade Hubot versions easily without having to copy over all our scripts, etc.

Thanks.
