### PR TITLE
Fix typo in mode of new file path

### DIFF
--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -17,7 +17,7 @@ class Creator
   mkdirDashP: (path) ->
     Path.exists path, (exists) ->
       unless exists
-        Fs.mkdir path, 0o0755, (err) ->
+        Fs.mkdir path, 0755, (err) ->
           throw err if err
 
   # Copy the contents of a file from one place to another.


### PR DESCRIPTION
This was causing "unexpected identifier" errors when starting up, at least with the shell adapter.
