### PR TITLE
Escape the hyphens in the roles regexes

### DIFF
--- a/src/scripts/roles.coffee
+++ b/src/scripts/roles.coffee
@@ -15,7 +15,7 @@ module.exports = (robot) ->
   getAmbiguousUserText = (users) ->
     "Be more specific, I know #{users.length} people named like that: #{(user.name for user in users).join(", ")}"
 
-  robot.respond /who is @?([\w .-]+)\?*$/i, (msg) ->
+  robot.respond /who is @?([\w .\-]+)\?*$/i, (msg) ->
     joiner = ', '
     name = msg.match[1].trim()
 
@@ -39,7 +39,7 @@ module.exports = (robot) ->
       else
         msg.send "#{name}? Never heard of 'em"
 
-  robot.respond /@?([\w .-_]+) is (["'\w: -_]+)[.!]*$/i, (msg) ->
+  robot.respond /@?([\w .\-_]+) is (["'\w: \-_]+)[.!]*$/i, (msg) ->
     name    = msg.match[1].trim()
     newRole = msg.match[2].trim()
 
@@ -63,7 +63,7 @@ module.exports = (robot) ->
         else
           msg.send "I don't know anything about #{name}."
 
-  robot.respond /@?([\w .-_]+) is not (["'\w: -_]+)[.!]*$/i, (msg) ->
+  robot.respond /@?([\w .\-_]+) is not (["'\w: \-_]+)[.!]*$/i, (msg) ->
     name    = msg.match[1].trim()
     newRole = msg.match[2].trim()
 


### PR DESCRIPTION
Inside square brackets, unescaped hyphens are position dependent. They act like hyphens normally when at the beginning or end of a square bracket expression. Otherwise it's used to signify a character range.

http://stackoverflow.com/questions/4068629/how-to-match-hyphens-with-regular-expression/4068725#4068725

Before: http://rubular.com/r/G1b3VgW4s4

After: http://rubular.com/r/yB8f1RYulj
