### PR TITLE
Check for null when there are no images

### DIFF
--- a/src/scripts/google-images.coffee
+++ b/src/scripts/google-images.coffee
@@ -37,8 +37,8 @@ imageMe = (msg, query, animated, faces, cb) ->
     .query(q)
     .get() (err, res, body) ->
       images = JSON.parse(body)
-      images = images.responseData.results
-      if images.length > 0
+      images = images.responseData?.results
+      if images?.length > 0
         image  = msg.random images
         cb "#{image.unescapedUrl}#.png"
 


### PR DESCRIPTION
if I did something like "hubot image me ablederfl33wo", I would get an error like:

/opt/hubot/scripts/google-images.coffee:47
      images = images.responseData.results;
                                                                ^
TypeError: Cannot read property 'results' of null
    at imageMe (/opt/hubot/scripts/google-images.coffee:47:35)
    at IncomingMessage.ScopedClient.request (/opt/hubot/node_modules/hubot/node_modules/scoped-http-client/lib/index.js:61:20)
    at IncomingMessage.EventEmitter.emit (events.js:126:20)
    at IncomingMessage._emitEnd (http.js:366:10)
    at HTTPParser.parserOnMessageComplete [as onMessageComplete](http.js:149:23)
    at Socket.socketOnEnd [as onend](http.js:1356:12)
    at TCP.onread (net.js:418:26)
