### PR TITLE
Use GET to get Campfire rooms, not POST

### DIFF
--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -96,7 +96,7 @@ class CampfireStreaming extends EventEmitter
     logger = @robot.logger
 
     show: (callback) ->
-      self.post "/room/#{id}", "", callback
+      self.get "/room/#{id}", "", callback
 
     join: (callback) ->
       self.post "/room/#{id}/join", "", callback


### PR DESCRIPTION
There's no need to use `POST` when fetching a room from Campfire, and doing so risks running up against Campfire's `POST` rate limit (50 `POST`s in 5 seconds).
