### PR TITLE
Give Message random ID so adapter could know which message it is replying on

### DIFF
--- a/src/response.coffee
+++ b/src/response.coffee
@@ -10,6 +10,7 @@ class Response
     @envelope =
       room: @message.room
       user: @message.user
+      message: @message
 
   # Public: Posts a message back to the chat source
   #


### PR DESCRIPTION
- When message instances are initiated, a 16-bytes random ID is given.
- In Response, message_id is also put in envelope so adapter could read that to know which message it is replying on.

In this way, a HTTP adapter could work. Please see this issue created by me: https://github.com/github/hubot/issues/389
