### PR TITLE
Update adapters to include a message id

### DIFF
--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -40,15 +40,15 @@ class Campfire extends Adapter
 
     bot.on "TextMessage", withAuthor (id, created, room, user, body, author) ->
       unless bot.info.id == author.id
-        self.receive new TextMessage(author, body)
+        self.receive new TextMessage(author, body, id)
 
     bot.on "EnterMessage", withAuthor (id, created, room, user, body, author) ->
       unless bot.info.id == author.id
-        self.receive new EnterMessage(author)
+        self.receive new EnterMessage(author, null, id)
 
     bot.on "LeaveMessage", withAuthor (id, created, room, user, body, author) ->
       unless bot.info.id == author.id
-        self.receive new LeaveMessage(author)
+        self.receive new LeaveMessage(author, null, id)
 
     bot.Me (err, data) ->
       bot.info = data.user

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -35,7 +35,7 @@ class Shell extends Adapter
       @repl.close() if buffer.toLowerCase() is 'exit'
       @repl.prompt()
       user = @userForId '1', name: 'Shell', room: 'Shell'
-      @receive new TextMessage user, buffer
+      @receive new TextMessage user, buffer, 'messageId'
 
     self.emit 'connected'
 

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -16,7 +16,8 @@ class TextMessage extends Message
   #
   # user - A User instance that sent the message.
   # text - A String message.
-  constructor: (@user, @text) ->
+  # id   - A String of the message ID.
+  constructor: (@user, @text, @id) ->
     super @user
 
   # Determines if the message matches the given regex.
@@ -30,11 +31,15 @@ class TextMessage extends Message
 # Represents an incoming user entrance notification.
 #
 # user - A User instance for the user who entered.
+# text - Always null.
+# id   - A String of the message ID.
 class EnterMessage extends Message
 
 # Represents an incoming user exit notification.
 #
 # user - A User instance for the user who left.
+# text - Always null.
+# id   - A String of the message ID.
 class LeaveMessage extends Message
 
 class CatchAllMessage extends Message


### PR DESCRIPTION
Received messages can now have a message ID to identify the message, useful for
the Campfire adapter.

Closes #401 

``` coffeescript
module.exports = (robot) ->
  robot.hear /wat/, (msg) ->
    robot.send "Message ID: #{msg.message.id}"
```
