### PR TITLE
listner.class expects utils.inspect to be available

### DIFF
--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -1,5 +1,7 @@
 {TextMessage} = require './message'
 
+inspect = require('util').inspect;
+
 class Listener
   # Listeners receive every message from the chat source and decide if they
   # want to act on it.


### PR DESCRIPTION
In the version of hubot 2.4.7 the listner class expects the utils.inspect method to be available. See [L22 of inspect.coffee](https://github.com/github/hubot/blob/master/src/listener.coffee#L22).

```
@robot.logger.debug "Message '#{message}' matched regex /#{inspect @regex}/" if @regex
```

Unfortunately the require on the util package is missing, so running hubot using the shell adapter throws following error.

```
bin/hubot -a shell
Hubot> hubot help
Hubot> [Tue Feb 26 2013 17:42:29 GMT+0100 (CET)] ERROR Unable to call the listener: ReferenceError: inspect is not defined
ReferenceError: inspect is not defined
    at TextListener.Listener.call (/Users/otamares/development/hubot/src/listener.coffee:20:82)
    at Robot.receive (/Users/otamares/development/hubot/src/robot.coffee:105:33)
    at Shell.Adapter.receive (/Users/otamares/development/hubot/src/adapter.coffee:37:25)
    at Interface.Shell.run (/Users/otamares/development/hubot/src/adapters/shell.coffee:74:22)
    at Interface.EventEmitter.emit (events.js:96:17)
    at Interface._onLine (readline.js:200:10)
    at Interface._line (readline.js:518:8)
    at Interface._ttyWrite (readline.js:736:14)
    at ReadStream.onkeypress (readline.js:97:10)
    at ReadStream.EventEmitter.emit (events.js:126:20)
```

Adding the appropriate require fixes the error

```
inspect = require('util').inspect;
```
