### PR TITLE
Update Readme to reflect new download file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Make sure you have [node.js][nodejs] and [npm][npmjs] (npm comes with node v0.6.
 
 Download the [latest version of hubot][hubot-latest].
 
-Then follow the instructions in the [README][readme] in the extracted `hubot`
-directory.
+Then follow the instructions in the [README][readme] in the extracted `hubot/src/templates`
+directory. The `templates` directory is an example runnable hubot.
 
 [nodejs]: http://nodejs.org
 [npmjs]: http://npmjs.org


### PR DESCRIPTION
Since Github has dropped support for downloads the link in Readme.md now points to the repository and not an example/template hubot.

I've updated some language after the link to point new users to the proper directory for a runnable hubot.
