### PR TITLE
Fix: route name in help.coffee (change ' -> ")

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -65,7 +65,7 @@ module.exports = (robot) ->
 
     msg.send emit
 
-  robot.router.get '/#{robot.name}/help', (req, res) ->
+  robot.router.get "/#{robot.name}/help", (req, res) ->
     cmds = robot.helpCommands().map (cmd) ->
       cmd.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
 


### PR DESCRIPTION
My previous change pushed in a bug to the http route of help.coffee. Was doing string interpolation with single quotes.
