### PR TITLE
fixing the json in package.json so that npm install works again

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "optparse":           "1.0.4",
     "scoped-http-client": "0.9.8",
     "log":                "1.3.1",
-    "express":            "3.1.0",
+    "express":            "3.1.0"
   },
 
   "engines": {


### PR DESCRIPTION
the final comma on this line was stopping npm parse the file when
running npm install
