### PR TITLE
Use Google's new animated imgtype for animate me

### DIFF
--- a/src/scripts/google-images.coffee
+++ b/src/scripts/google-images.coffee
@@ -31,7 +31,7 @@ imageMe = (msg, query, animated, faces, cb) ->
   cb = animated if typeof animated == 'function'
   cb = faces if typeof faces == 'function'
   q = v: '1.0', rsz: '8', q: query, safe: 'active'
-  q.as_filetype = 'gif' if typeof animated is 'boolean' and animated is true
+  q.imgtype = 'animated' if typeof animated is 'boolean' and animated is true
   q.imgtype = 'face' if typeof faces is 'boolean' and faces is true
   msg.http('http://ajax.googleapis.com/ajax/services/search/images')
     .query(q)


### PR DESCRIPTION
Rather than just search for GIFs, search for imgtype="animated".
