### PR TITLE
Update README.md

### DIFF
--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -49,7 +49,7 @@ about redis at all.
 
 You can test your hubot by running the following.
 
-    % bin/hubot
+    % PATH="node_modules/.bin:$PATH" bin/hubot
 
 You'll see some start up output about where your scripts come from and a
 prompt.


### PR DESCRIPTION
Fixing the command to run hubot locally, so users don't have to add node_modules to their path.
