### PR TITLE
Fix constructor for CatchAllMessages

### DIFF
--- a/src/message.coffee
+++ b/src/message.coffee
@@ -54,6 +54,7 @@ class CatchAllMessage extends Message
   #
   # message - The original message.
   constructor: (@message) ->
+    super @message.user
 
 module.exports = {
   Message


### PR DESCRIPTION
Currently, CatchAllMessages do not have the user or room set correctly. This fix just calls the correct parent constructor to ensure that this happens.
