### PR TITLE
Fix robot.respond bug which is occurred by unescaped robot.name

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -80,16 +80,17 @@ class Robot
       @logger.warning "The regex in question was #{regex.toString()}"
 
     pattern = re.join('/')
+    name = @name.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
 
     if @alias
       alias = @alias.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
       newRegex = new RegExp(
-        "^[@]?(?:#{alias}[:,]?|#{@name}[:,]?)\\s*(?:#{pattern})"
+        "^[@]?(?:#{alias}[:,]?|#{name}[:,]?)\\s*(?:#{pattern})"
         modifiers
       )
     else
       newRegex = new RegExp(
-        "^[@]?#{@name}[:,]?\\s*(?:#{pattern})",
+        "^[@]?#{name}[:,]?\\s*(?:#{pattern})",
         modifiers
       )
 


### PR DESCRIPTION
Hello team.

I have found `robot.respond` bug which is occurred by unescaped `robot.name`.

http://www.ietf.org/rfc/rfc1459.txt
IRC nickname is allowed to use any regex reserved characters, so `robot.name` should be escaped. I want to make an IRC bot whom I named `[^o^]`, but I can't it for this bug. :disappointed_relieved:

Could you review it? Thanks.
