### PR TITLE
Add a default User-Agent for HTTP requests

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -415,5 +415,6 @@ class Robot
   # Returns a ScopedClient instance.
   http: (url) ->
     HttpClient.create(url)
+      .header('User-Agent', 'Hubot')
 
 module.exports = Robot


### PR DESCRIPTION
The github.com API now requires this (see http://developer.github.com/v3/#user-agent-required), and it seems like a good thing to do in any case.
