### PR TITLE
Fix - keepalive ping for heroku needs to match httpd.coffee

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -240,7 +240,7 @@ class Robot
     if herokuUrl
       herokuUrl += '/' unless /\/$/.test herokuUrl
       setInterval =>
-        HttpClient.create("#{herokuUrl}hubot/ping").post() (err, res, body) =>
+        HttpClient.create("#{herokuUrl}#{@name}/ping").post() (err, res, body) =>
           @logger.info 'keep alive ping!'
       , 1200000
 


### PR DESCRIPTION
Please see this discussion that @technicalpickles started.
        https://github.com/github/hubot/commit/0fbcf74#commitcomment-3077952

Looks like I introduced a very serious bug for folks running hubot on heroku in commit https://github.com/github/hubot/commit/0fbcf74.

httpd.coffee was updated in an earlier commit. The corresponding change to robot.coffee was missed. We now ping `#{robot.name}/ping` instead of `hubot/ping`

Instead, I think it would be a fair call to simply `git revert 0fbcf74` and go back to how it was. httpd.coffee consists purely of admin stuff.
