### PR TITLE
fix mkdir problems with hubot --create

### DIFF
--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -14,7 +14,7 @@ class Creator
   # Create a folder if it doesn't already exist.
   #
   # Returns nothing.
-  mkdirDashP: (path) ->
+  mkdir: (path) ->
     Fs.exists path, (exists) ->
       unless exists
         Fs.mkdirSync path, 0o0755
@@ -53,9 +53,9 @@ class Creator
   run: ->
     console.log "Creating a hubot install at #{@path}"
 
-    @mkdirDashP(@path)
-    @mkdirDashP("#{@path}/bin")
-    @mkdirDashP("#{@path}/scripts")
+    @mkdir(@path)
+    @mkdir("#{@path}/bin")
+    @mkdir("#{@path}/scripts")
 
     @copyDefaultScripts("#{@path}/scripts")
 


### PR DESCRIPTION
If you `hubot --create` from a github/hubot clone you get an ENOENT from creator.coffee:20 leaving you without a new hubot. The problem is the mkdirDashP function. That thing doesn't actually do -p and its asyncronicity is causing problems with the three mkdirDashP calls in creator.coffee around line 57. My guess is the second mkdirDashP runs into ENOENT because the first one hasn't been completed yet.

These commits fix the problem and the name of the function.
