### PR TITLE
parse help for external scripts

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -213,6 +213,7 @@ class Robot
     for pkg in packages
       try
         require(pkg) @
+        @parseHelp require.resolve(pkg)
       catch error
         @logger.error "Error loading scripts from npm package - #{error}"
         process.exit(1)


### PR DESCRIPTION
scripts added via npm weren't getting their help parsed. this adds a
call to parse the help docs using node's `require.resolve` to figure out
the path.
