### PR TITLE
Delay Brain's auto-saving until robot emits a 'running' event

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -77,8 +77,7 @@ class Brain extends EventEmitter
   resetSaveInterval: (seconds) ->
     clearInterval @saveInterval if @saveInterval
     @saveInterval = setInterval =>
-      if @autoSave
-        @save()
+      @save() if @autoSave
     , seconds * 1000
 
   # Public: Merge keys loaded from a DB against the in memory representation.

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -369,7 +369,7 @@ class Robot
   #
   # Returns nothing.
   run: ->
-    @emit "running", {}
+    @emit "running"
     @adapter.run()
 
   # Public: Gracefully shutdown the robot process


### PR DESCRIPTION
Also adds a public method for disabling the auto-saving mechanism.

Allows *-brain scripts to stop auto-saving until they've got their
stuff in-order.

Should resolve #510
