### PR TITLE
Fix youtube script no results bug

### DIFF
--- a/src/scripts/youtube.coffee
+++ b/src/scripts/youtube.coffee
@@ -6,7 +6,7 @@
 module.exports = (robot) ->
   robot.respond /(youtube|yt)( me)? (.*)/i, (msg) ->
     query = msg.match[3]
-    msg.http("http://gdata.youtube.com/feeds/api/videos")
+    robot.http("http://gdata.youtube.com/feeds/api/videos")
       .query({
         orderBy: "relevance"
         'max-results': 15


### PR DESCRIPTION
The YouTube Hubot script crashes when calling `msg.random` if the query returns no results.

I handled this case and also changed the http call to use `robot.http` rather than the deprecated `msg.http`. The message sent back to the chat room is the same as what YouTube shows when no results return.
