### PR TITLE
AWS Elastic Beanstalk support

### DIFF
--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -31,5 +31,9 @@
   "engines": {
     "node": ">= 0.8.x",
     "npm":  ">= 1.1.x"
+  },
+
+  "scripts": {
+    "start": "bin/hubot -a campfire -n Hubot"
   }
 }


### PR DESCRIPTION
Creating a deployable hubot (via `hubot -c`) doesn't Just Work™ when deploying to AWS Elastic Beanstalk out of the box - it was unable to find a start script to get it running.

I copied the same command used by foreman in `Procfile` (primarily for Heroku) and placed it in package.json as a start script. EB is now able to successfully start hubot (`npm start` will now work as well).
- Notes
  - AWS Container Type: 64bit Amazon Linux running Node.js
  - This change does create some minor duplication between `Procfile` and `package.json`
