### PR TITLE
Update help.coffee to use robot.alias if it's defined

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -53,18 +53,21 @@ helpContents = (name, commands) ->
 module.exports = (robot) ->
   robot.respond /help\s*(.*)?$/i, (msg) ->
     cmds = robot.helpCommands()
+    filter = msg.match[1]
 
-    if msg.match[1]
+    if filter
       cmds = cmds.filter (cmd) ->
-        cmd.match new RegExp(msg.match[1], 'i')
-
+        cmd.match new RegExp(filter, 'i')
       if cmds.length == 0
-        msg.send "No available commands match #{msg.match[1]}"
+        msg.send "No available commands match #{filter}"
         return
-    emit = cmds.join "\n"
 
-    unless robot.name.toLowerCase() is 'hubot'
-      emit = emit.replace /hubot/ig, robot.name
+    prefix = robot.alias or "#{robot.name} "
+    cmds = cmds.map (cmd) ->
+      cmd = cmd.replace /^hubot /, prefix
+      cmd.replace /hubot/ig, robot.name
+
+    emit = cmds.join "\n"
 
     msg.send emit
 


### PR DESCRIPTION
Previously, if you specifed an alias like '/', it wouldn't be reflected in `/help`'s
output, instead just showing the robot name.
