### PR TITLE
Don't build master on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
+branches:
+  except:
+    - master
 notifications:
   email: false


### PR DESCRIPTION
This ignores `master` as that's still our old tests on Travis-CI.
