### PR TITLE
Heroku ping url is HEROKU_URL, not HUBOT_HEROKU_URL

### DIFF
--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -47,7 +47,7 @@ there's a special environment variable to make hubot regularly ping itself over 
 the app is deployed to http://rosemary-britches-123.herokuapp.com/, then you'd
 configure:
 
-    % heroku config:add HUBOT_HEROKU_URL=http://rosemary-britches-123.herokuapp.com
+    % heroku config:add HEROKU_URL=http://rosemary-britches-123.herokuapp.com
 
 At this point, you are ready to deploy and start chatting. With Heroku, that's a
 git push away:


### PR DESCRIPTION
Seems like the docs report the wrong environment variable to set to get Hubot to ping itself and keep your heroku dyno from going idle. Docs current report it as `HUBOT_HEROKU_URL`, looks like `robot.coffee` is using `HEROKU_URL` See: https://github.com/github/hubot/blob/master/src/robot.coffee#L240 for reference.
