### PR TITLE
v3: Uncaught Exception Handling

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -123,7 +123,7 @@ class Robot extends EventEmitter
   # callback - A Function that is called with the error object.
   #
   # Returns nothing.
-  addErrorHandler: (callback) ->
+  error: (callback) ->
     @errorHandlers.push callback
 
   # Private: Calls and passes any registered error handlers for unhandled


### PR DESCRIPTION
Allows users to add `robot.on 'error', (err) -> something()` to a script and maybe report uncaught exceptions somewhere. These are **uncaught** exceptions, this won't report any errors that have been handled internally.
