### PR TITLE
Removing broken twilio adapter link

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -20,7 +20,7 @@ to have yours added to the list:
 * [IRC](https://github.com/nandub/hubot-irc)
 * [Partychat](https://github.com/iangreenleaf/hubot-partychat-hooks)
 * [Talker](https://github.com/unixcharles/hubot-talker)
-* [Twilio](https://github.com/egparedes/hubot-twilio)
+* [Twilio](https://github.com/jkarmel/hubot-twilio)
 * [Twitter](https://github.com/MathildeLemee/hubot-twitter)
 * [XMPP](https://github.com/markstory/hubot-xmpp)
 * [Gtalk](https://github.com/atmos/hubot-gtalk)


### PR DESCRIPTION
Looks like the repo has been deleted.

~~I found [neilcauldwell/hubot-twilio](https://github.com/neilcauldwell/hubot-twilio) but it doesn't look very active. I can swap out the links and rebase the commit if that's preferable.~~ :bowtie:

The link now matches the repo found on NPM.
