### PR TITLE
Fix prefix whitespace in help output when an alias is used.

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -62,7 +62,7 @@ module.exports = (robot) ->
         msg.send "No available commands match #{filter}"
         return
 
-    prefix = robot.alias or "#{robot.name} "
+    prefix = if robot.alias then "#{robot.alias} " else "#{robot.name} "
     cmds = cmds.map (cmd) ->
       cmd = cmd.replace /^hubot /, prefix
       cmd.replace /hubot/ig, robot.name


### PR DESCRIPTION
Previously, showing the help would result in something as:
`<Alias>ping - Reply with pong`
without any whitespace between the alias and the command.
