### PR TITLE
Add usersWithRole to the Auth class in auth.coffee

### DIFF
--- a/src/scripts/auth.coffee
+++ b/src/scripts/auth.coffee
@@ -46,6 +46,7 @@ module.exports = (robot) ->
         for role in roles
           return true if role in user.roles
       return false
+
     usersWithRole: (role) ->
       users = []
       for own key, user of robot.brain.data.users


### PR DESCRIPTION
This allows scripts to list out all users with a specific role by calling robot.auth.usersWithRole.

I'm using this for a group notification script as well as for a shared twitter account script.
