### PR TITLE
Fix help script spacing

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -1,4 +1,4 @@
-# Description: 
+# Description:
 #   Generates help commands for Hubot.
 #
 # Commands:
@@ -62,9 +62,9 @@ module.exports = (robot) ->
         msg.send "No available commands match #{filter}"
         return
 
-    prefix = robot.alias or "#{robot.name} "
+    prefix = robot.alias or robot.name
     cmds = cmds.map (cmd) ->
-      cmd = cmd.replace /^hubot /, prefix
+      cmd = cmd.replace /^hubot/, prefix
       cmd.replace /hubot/ig, robot.name
 
     emit = cmds.join "\n"


### PR DESCRIPTION
Previously spaces were replaced when using a hubot alias, now spaces are retained from the initial script documentation. For example `marvindie - End HubotBot process` is now corrected to `marvin die - End HubotBot process`.
