### PR TITLE
Add 'authors' documentation section

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -22,6 +22,7 @@ HUBOT_DOCUMENTATION_SECTIONS = [
   'commands'
   'notes'
   'author'
+  'authors'
   'examples'
   'tags'
   'urls'


### PR DESCRIPTION
There are several hubot scripts that have `Authors:` block with two or more people instead of `Author:`

```
src/scripts/deploy.coffee
20:# Authors:

src/scripts/do-it.coffee
173:Authors do it by rote.

src/scripts/flip.coffee
12:# Authors:

src/scripts/frick.coffee
13:# Authors:

src/scripts/github-commits.coffee
18:# Authors:

src/scripts/github-pull-request-notifier.coffee
23:# Authors:

src/scripts/jenkins-notifier.coffee
22:# Authors:

src/scripts/mindkiller.coffee
14:# Authors:

src/scripts/one_four_twentyfour.coffee
18:# Authors:

src/scripts/pagerduty.coffee
43:# Authors:

src/scripts/room-info.coffee
13:# Authors:
```

When any of these scripts are included, `hubot help` prints author names as commands.
