### PR TITLE
Uniquify Error Logs in Campfire Adapter

### DIFF
--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -285,6 +285,7 @@ class CampfireStreaming extends EventEmitter
               throw new Error "Invalid access token provided"
             else
               logger.error "Campfire HTTPS status code: #{response.statusCode}"
+              logger.error "Campfire HTTPS response data: #{data}"
 
         if callback
           try


### PR DESCRIPTION
- make the error messages emitted from the Campfire adapter all unique, so that they're easier to trace down
- add logging of the body text for the case of HTTPS status codes > 401; the additional reason information can be really helpful
