### PR TITLE
Consistent script load order 

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -194,7 +194,7 @@ class Robot
     @logger.debug "Loading scripts from #{path}"
     Fs.exists path, (exists) =>
       if exists
-        for file in Fs.readdirSync(path)
+        for file in Fs.readdirSync(path).sort()
           @loadFile path, file
 
   # Public: Load scripts specfied in the `hubot-scripts.json` file.


### PR DESCRIPTION
Came across this while moving our hubot to a different OS & node version. There was load-order dependent script, ie `scripts/1-twitter.coffee` was named to load first, then everything else. Scripts depending on that were failing because it hadn't been loaded yet.

This sorts files before loading them, in order to be consistent across whatever.

cc @jfryman 
