### PR TITLE
Fix #603: Re-enable external script help parsing

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -220,6 +220,7 @@ class Robot
       if packages instanceof Array
         for pkg in packages
           require(pkg)(@)
+          @parseHelp require.resolve(pkg)
       else
         for pkg, scripts of packages
           require(pkg)(@, scripts)


### PR DESCRIPTION
This fixed issue #603.  Re-enable help parsing for external scripts.  Help parsing for external
scripts was added in 9435251 and for some reason removed in 2279967.
