### PR TITLE
Allow Hubot to work on OpenShift, where it must bind to a particular IP.

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -244,7 +244,7 @@ class Robot
     app.use express.static stat if stat
 
     try
-      @server = app.listen(process.env.PORT || 8080, process.env.HOSTNAME || '0.0.0.0')
+      @server = app.listen(process.env.PORT || 8080, process.env.BIND_ADDRESS || '0.0.0.0')
       @router = app
     catch err
       @logger.error "Error trying to start HTTP server: #{err}\n#{err.stack}"


### PR DESCRIPTION
OpenShift is a popular open-source PaaS platform with node.js support. Hubot works great on it, except that all apps are required to listen on a specific port for security reasons. With this pull request in place, Hubot's HTTP server will work on OpenShift.
