### PR TITLE
Add options argument to robot.http

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -418,6 +418,7 @@ class Robot
   # send the request.
   #
   # url - String URL to access.
+  # options - Optional options to pass on to the client
   #
   # Examples:
   #
@@ -439,9 +440,12 @@ class Robot
   #       .post(data) (err, res, body) ->
   #         console.log body
   #
+  #    # Can also set options
+  #    res.http("http://example.com", {rejectUnauthorized: false})
+  #
   # Returns a ScopedClient instance.
-  http: (url) ->
-    HttpClient.create(url)
+  http: (url, options) ->
+    HttpClient.create(url, options)
       .header('User-Agent', "Hubot/#{@version}")
 
 module.exports = Robot


### PR DESCRIPTION
This adds the options argument that is part of the [create call/constructor](https://github.com/technoweenie/node-scoped-http-client/blob/4d0807defe6e65a022cca0a6302e1cc895a1f86c/src/index.coffee#L171-L172) from the [scoped http client](https://github.com/technoweenie/node-scoped-http-client).
