### PR TITLE
Replace shut down Google calculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "optparse":           "1.0.4",
     "scoped-http-client": "0.9.8",
     "log":                "1.4.0",
-    "express":            "3.3.4"
+    "express":            "3.3.4",
+    "mathjs":             "0.16.0"
   },
 
   "engines": {

--- a/src/scripts/math.coffee
+++ b/src/scripts/math.coffee
@@ -3,20 +3,8 @@
 #
 # Commands:
 #   hubot math me <expression> - Calculate the given expression.
-#   hubot convert me <expression> to <units> - Convert expression to given units.
 module.exports = (robot) ->
-  robot.respond /(calc|calculate|calculator|convert|math|maths)( me)? (.*)/i, (msg) ->
-    msg
-      .http('https://www.google.com/ig/calculator')
-      .query
-        hl: 'en'
-        q: msg.match[3]
-      .headers
-        'Accept-Language': 'en-us,en;q=0.5',
-        'Accept-Charset': 'utf-8',
-        'User-Agent': "Mozilla/5.0 (X11; Linux x86_64; rv:2.0.1) Gecko/20100101 Firefox/4.0.1"
-      .get() (err, res, body) ->
-        # Response includes non-string keys, so we can't use JSON.parse here.
-        json = eval("(#{body})")
-        msg.send json.rhs || 'Could not compute.'
-
+  robot.respond /(calc|calculate|calculator|math|maths)( me)? (.*)/i, (msg) ->
+    mathjs = require('mathjs')
+    math = mathjs()
+    msg.send math.eval(msg.match[3])


### PR DESCRIPTION
Since iGoogle has been shutdown, the iGoogle Calculator no longer works. Instead I pulled in the mathjs library to evaluate arbitrary math expressions locally.

Conversions aren't working as expected, removed it from the expressions to listen to. Should be doable though. At this point Hubot doesn't crash when you calculate.

This isn't fully complete but I did want to see what the thoughts would be around including another library to do math, or if the preference would be towards an API. One web API that comes to mind is Wolfram Alpha, but you'd need an account.
