### PR TITLE
Hubot shouldn't exit chat by failed script

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -100,7 +100,10 @@ class Robot
         modifiers
       )
 
-    @listeners.push new TextListener(@, newRegex, callback)
+    try
+      @listeners.push new TextListener(@, newRegex, callback)
+    catch err
+      @logger.error "One of the scripts failed.\n#{err}"
 
   # Public: Adds a Listener that triggers when anyone enters the room.
   #


### PR DESCRIPTION
Currently if any of the scripts have an exception, hubot actually ends up leaving the chat and then has to be restarted.

Failing silently isn't great either, but at least hubot sticks around.
