### PR TITLE
Fix user role message grammar in auth.coffee.

### DIFF
--- a/src/scripts/auth.coffee
+++ b/src/scripts/auth.coffee
@@ -98,12 +98,15 @@ module.exports = (robot) ->
     user = robot.brain.userForName(name)
     return msg.reply "#{name} does not exist" unless user?
     user.roles or= []
+    displayRoles = user.roles
 
     if user.id.toString() in admins
-      isAdmin = ' and is also an admin'
+      displayRoles.push('admin')
+
+    if displayRoles.length == 0
+      msg.reply "#{name} has no roles."
     else
-      isAdmin = ''
-    msg.reply "#{name} has the following roles: #{user.roles.join(', ')}#{isAdmin}."
+      msg.reply "#{name} has the following roles: #{displayRoles.join(', ')}."
 
   robot.respond /who has admin role\?*$/i, (msg) ->
     adminNames = []
@@ -111,4 +114,7 @@ module.exports = (robot) ->
       user = robot.brain.userForId(admin)
       adminNames.push user.name if user?
 
-    msg.reply "The following people have the 'admin' role: #{adminNames.join(', ')}"
+    if adminNames.length > 0
+      msg.reply "The following people have the 'admin' role: #{adminNames.join(', ')}"
+    else
+      msg.reply "There are no people that have the 'admin' role."


### PR DESCRIPTION
If I have a user that is just an admin, then the following happens:

hubot what role does Dave Reid have?
Dave Reid has the following roles:  and is also an admin.

I propose the following fix to just list all the roles in a comma separated list (including 'admin') without the special handling for 'and is also an admin'. Also contains a fix if the admin environment variable is defined, but is empty.
