### PR TITLE
Emit `msg` whenever possible along with `err`

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -195,7 +195,8 @@ class Robot
         results.push listener.call(message)
         break if message.done
       catch error
-        @emit('error', error, message)
+        @emit('error', error, new @Response(@, message, []))
+
         false
     if message not instanceof CatchAllMessage and results.indexOf(true) is -1
       @receive new CatchAllMessage(message)


### PR DESCRIPTION
Error handlers get passed the received error and a `msg` object. They can check if `msg` is defined, and `msg.reply` to the user with whta happened and where to get more info.

The problem is that hubot script writers need to explicitly catch and emit the error, along with the `msg`, which ends up being a bit boilerplatey. There's not much hubot core can do (yet) for asynchronous code, but we already `try/catch` when invoking listners, and emit 'error'. This PR updates that logic to also build a `msg` (which is actually a Repsonse) along with it, so any synchronous code in the listeners will have the extra context of the `msg`.
