### PR TITLE
Add missing colon

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -481,7 +481,7 @@ For the second example, it's worth thinking about what messages the user would s
 Hubot scripts can be documented with comments at the top of their file, for example:
 
 ```coffeescript
-# Description
+# Description:
 #   <description of the scripts functionality>
 #
 # Dependencies:


### PR DESCRIPTION
Shamefully small change, but all the scripts I've seen have `Description:`, not `Description`, so I presume colon should be there.
