### PR TITLE
Fix broken link in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Getting Started With Hubot
 
-You will need [node.js](nodejs.org/) and [npm](https://npmjs.org/). Joyent has
+You will need [node.js](http://nodejs.org/) and [npm](https://npmjs.org/). Joyent has
 an [excellent blog post on how to get those installed](http://joyent.com/blog/installing-node-and-npm), so we'll omit those details here.
 
 Once node and npm are ready, we can install hubot and coffeescript:


### PR DESCRIPTION
The url without protocol links to the following:
- https://github.com/github/hubot/blob/master/docs/nodejs.org/

But this url is NOT FOUND :disappointed:
