### PR TITLE
Fix link to license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 
   "licenses": [{
     "type": "MIT",
-    "url": "https://github.com/github/hubot/raw/master/LICENSE.md"
+    "url": "https://raw.github.com/github/hubot/master/LICENSE"
   }],
 
   "repository" : {


### PR DESCRIPTION
`LICENSE.md` is not found.
