### PR TITLE
Set "private": true to avoid npm publish

### DIFF
--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -1,6 +1,7 @@
 {
   "name": "hosted-hubot",
   "version": "2.7.1",
+  "private": true,
 
   "author": "GitHub Inc.",
 


### PR DESCRIPTION
This field is appropriate for generated projects that shouldn't (by default) be intended to be published to the npm registry via `npm publish`. Setting this flag will prevent accidental publication.
