### PR TITLE
Specify charset to html for help

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -17,6 +17,7 @@ helpContents = (name, commands) ->
 <!DOCTYPE html>
 <html>
   <head>
+  <meta charset="utf-8">
   <title>#{name} Help</title>
   <style type="text/css">
     body {


### PR DESCRIPTION
I want to use multibyte characters in command description.

Before:
![2014-01-17 14 08 52](https://f.cloud.github.com/assets/290782/1937886/a4b27e86-7f35-11e3-9801-6ff4e9828b54.png)

After:
![2014-01-17 14 09 16](https://f.cloud.github.com/assets/290782/1937887/a7a04e34-7f35-11e3-9696-07d8388a51a2.png)

The latter isn't garbled characters.
