### PR TITLE
Fix old command for heroku toolbelt

### DIFF
--- a/docs/adapters/campfire.md
+++ b/docs/adapters/campfire.md
@@ -50,11 +50,11 @@ subdomain is `hubot`. Make a note of the subdomain.
 
 ### Configuring the variables on Heroku
 
-    % heroku config:add HUBOT_CAMPFIRE_TOKEN="..."
+    % heroku config:set HUBOT_CAMPFIRE_TOKEN="..."
 
-    % heroku config:add HUBOT_CAMPFIRE_ROOMS="123,321"
+    % heroku config:set HUBOT_CAMPFIRE_ROOMS="123,321"
 
-    % heroku config:add HUBOT_CAMPFIRE_ACCOUNT="..."
+    % heroku config:set HUBOT_CAMPFIRE_ACCOUNT="..."
 
 ### Configuring the variables on UNIX
 

--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -32,9 +32,9 @@ variables for hubot to use. The specific variables you'll need depends on which
 [adapter](../adapters.md) and scripts you are using. For Campfire, with no other
 scripts, you'd need to set the following environment variables:
 
-    % heroku config:add HUBOT_CAMPFIRE_ACCOUNT=yourcampfireaccount
-    % heroku config:add HUBOT_CAMPFIRE_TOKEN=yourcampfiretoken
-    % heroku config:add HUBOT_CAMPFIRE_ROOMS=comma,separated,list,of,rooms,to,join
+    % heroku config:set HUBOT_CAMPFIRE_ACCOUNT=yourcampfireaccount
+    % heroku config:set HUBOT_CAMPFIRE_TOKEN=yourcampfiretoken
+    % heroku config:set HUBOT_CAMPFIRE_ROOMS=comma,separated,list,of,rooms,to,join
 
 In addition, there is one special environment variable for Heroku. The default hubot
 [Procfile](https://devcenter.heroku.com/articles/procfile) marks the process as
@@ -47,7 +47,7 @@ there's a special environment variable to make hubot regularly ping itself over 
 the app is deployed to http://rosemary-britches-123.herokuapp.com/, you'd
 configure:
 
-    % heroku config:add HEROKU_URL=http://rosemary-britches-123.herokuapp.com
+    % heroku config:set HEROKU_URL=http://rosemary-britches-123.herokuapp.com
 
 At this point, you are ready to deploy and start chatting. With Heroku, that's a
 git push away:

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -43,7 +43,7 @@ If you are going to use the `redis-brain.coffee` script from `hubot-scripts`
 account or you can create an account at [Redis to Go][redistogo] and manually
 set the `REDISTOGO_URL` variable.
 
-    % heroku config:add REDISTOGO_URL="..."
+    % heroku config:set REDISTOGO_URL="..."
 
 If you don't require any persistence feel free to remove the
 `redis-brain.coffee` from `hubot-scripts.json` and you don't need to worry
@@ -136,18 +136,18 @@ of those, links to the adapters can be found on [Hubot Adapters][hubot-adapters]
 Create a separate Campfire user for your bot and get their token from the web
 UI.
 
-    % heroku config:add HUBOT_CAMPFIRE_TOKEN="..."
+    % heroku config:set HUBOT_CAMPFIRE_TOKEN="..."
 
 Get the numeric IDs of the rooms you want the bot to join, comma delimited. If
 you want the bot to connect to `https://mysubdomain.campfirenow.com/room/42` 
 and `https://mysubdomain.campfirenow.com/room/1024` then you'd add it like this:
 
-    % heroku config:add HUBOT_CAMPFIRE_ROOMS="42,1024"
+    % heroku config:set HUBOT_CAMPFIRE_ROOMS="42,1024"
 
 Add the subdomain hubot should connect to. If you web URL looks like
 `http://mysubdomain.campfirenow.com` then you'd add it like this:
 
-    % heroku config:add HUBOT_CAMPFIRE_ACCOUNT="mysubdomain"
+    % heroku config:set HUBOT_CAMPFIRE_ACCOUNT="mysubdomain"
 
 [hubot-adapters]: https://github.com/github/hubot/blob/master/docs/adapters.md
 


### PR DESCRIPTION
`heroku config:add` works but it is previous version's.
- https://devcenter.heroku.com/articles/config-vars#setting-up-config-vars-for-a-deployed-application

So I rewrite `config:add` with `config:set`.
