### PR TITLE
Custom messages methods for Response and Adapter implemented

### DIFF
--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -41,6 +41,14 @@ class Adapter extends EventEmitter
   # Returns nothing.
   topic: (envelope, strings...) ->
 
+  # Public: Raw method for sending custom data back to the chat source. Extend this.
+  #
+  # envelope - A Object with message, room and user details.
+  # objects  - One or more custom Objects for each message to send.
+  #
+  # Returns nothing.
+  custom: (envelope, objects...) ->
+
   # Public: Raw method for playing a sound in the chat source. Extend this.
   #
   # envelope - A Object with message, room and user details.

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -48,6 +48,14 @@ class Response
   topic: (strings...) ->
     @robot.adapter.topic @envelope, strings...
 
+  # Public: Posts a custom message
+  #
+  # objects - One or more objects to be posted
+  #
+  # Returns nothing.
+  custom: (objects...) ->
+    @robot.adapter.custom @envelope, objects...
+
   # Public: Play a sound in the chat source
   #
   # strings - One or more strings to be posted as sounds to play. The order of


### PR DESCRIPTION
I was thinking about this PR in slack adapter repository tinyspeck/hubot-slack#24 and realised that currently we have no ability to send something more complex to the chatroom rather then plain text. 

My PR implements Adapter#custom raw method and Response#custom method. 
Adapter#custom should be extended by adapters that require some additional message types to be sent. 

According to usecase of slack described in related PR it might look something like this:

``` coffee-script
robot.respond /foo$/i, (msg) ->
  data = 
    type: 'slack-attachment'
    content:
      text: "Optional text that should appear within the attachment"
      color: "#36a64f"
  msg.custom data
```

in this case adapter should handle itself how to parse objects received and send them back to a chat in appropriate way.

This change should not break anything, but should give extra abilities for adapter developers. 
