### PR TITLE
fix making a user an admin multiple times over

### DIFF
--- a/src/scripts/auth.coffee
+++ b/src/scripts/auth.coffee
@@ -101,7 +101,7 @@ module.exports = (robot) ->
     displayRoles = user.roles
 
     if user.id.toString() in admins
-      displayRoles.push('admin')
+      displayRoles.push('admin') unless 'admin' in user.roles
 
     if displayRoles.length == 0
       msg.reply "#{name} has no roles."
@@ -112,7 +112,8 @@ module.exports = (robot) ->
     adminNames = []
     for admin in admins
       user = robot.brain.userForId(admin)
-      adminNames.push user.name if user?
+      unless robot.auth.hasRole(msg.envelope.user,'admin')
+        adminNames.push user.name if user?
 
     if adminNames.length > 0
       msg.reply "The following people have the 'admin' role: #{adminNames.join(', ')}"


### PR DESCRIPTION
When integrating one of my own scripts with roles, I noticed that whenever I queried who was an admin or who had a given role, the 'admin' role would be added to the roles again and again. This mean that my user had the roles "admin,admin,admin.admin". This seems to fix it.
