### PR TITLE
Alllow hubot scripts to be written in other languages

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -211,7 +211,7 @@ class Robot
   loadFile: (path, file) ->
     ext  = Path.extname file
     full = Path.join path, Path.basename(file, ext)
-    if ext is '.coffee' or ext is '.js'
+    if require.extensions[ext]
       try
         require(full) @
         @parseHelp Path.join(path, file)


### PR DESCRIPTION
`require.extensions` will include '.js' and '.coffee', but also potentially could include other extensions if they've been registered with `require`.
