### PR TITLE
Userforid reconciliation

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -100,17 +100,8 @@ class Brain extends EventEmitter
   # Public: Get a User object given a unique identifier.
   #
   # Returns a User instance of the specified user.
-  userForId: (id, options) ->
-    user = @data.users[id]
-    unless user
-      user = new User id, options
-      @data.users[id] = user
-
-    if options and options.room and (!user.room or user.room isnt options.room)
-      user = new User id, options
-      @data.users[id] = user
-
-    user
+  userForId: (id, options={}) ->
+    @data.users[id] = extend {}, (@data.users[id] or {}), options
 
   # Public: Get a User object given a name.
   #

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -100,8 +100,10 @@ class Brain extends EventEmitter
   # Public: Get a User object given a unique identifier.
   #
   # Returns a User instance of the specified user.
-  userForId: (id, options={}) ->
-    @data.users[id] = extend {}, (@data.users[id] or {}), options
+  # If a second argument is passed the used is updated with any attributes contained in that object
+  userForId: (id, options) ->
+    return unless @data.users[id]? or options? #If we're getting a user that doesn't exist short out
+    @data.users[id] = extend {}, (@data.users[id] or {}), (options or {})
 
   # Public: Get a User object given a name.
   #

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -101,9 +101,10 @@ class Brain extends EventEmitter
   #
   # Returns a User instance of the specified user.
   # If a second argument is passed the used is updated with any attributes contained in that object
-  userForId: (id, options) ->
-    return unless @data.users[id]? or options? #If we're getting a user that doesn't exist short out
-    @data.users[id] = extend {}, (@data.users[id] or {}), (options or {})
+  userForId: (id, new_attribs) ->
+    return unless @data.users[id]? or new_attribs? #If we're getting a user that doesn't exist short out
+    options = extend {}, (@data.users[id] or {}), (new_attribs or {})
+    @data.users[id] = new User id, options
 
   # Public: Get a User object given a name.
   #

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -102,7 +102,7 @@ class Brain extends EventEmitter
   # Returns a User instance of the specified user.
   # If a second argument is passed the used is updated with any attributes contained in that object
   userForId: (id, new_attribs) ->
-    return unless @data.users[id]? or new_attribs? #If we're getting a user that doesn't exist short out
+    return @data.users[id] unless new_attribs? # If no new attribs just return the existing user
     options = extend {}, (@data.users[id] or {}), (new_attribs or {})
     @data.users[id] = new User id, options
 


### PR DESCRIPTION
We were seeing strange failures with our hubot. I was able to trace it down to the `brain.userForId` function, which I then updated to solve the issue. I'm going to outline the failure and the changes made to fix it below. If I'm missing anything as far as why this function was originally coded like it was then I can look at fixing the issue in other ways, but in the context I can see this fix is fairly straightforward. 
### The Issue

Ever since we started using the brain to store info on users we noticed a strange failure where new users weren't having @mention_names assigned. 

What appears to be the problem is initially when users are created (in hipchat) they don't have @mention_names. Hubot adds them to the brain as soon as they exist. Then when @mention_name is set the `userForId` function is called again it doesn't update the brain because of the conditions on [line 109](https://github.com/templaedhel/hubot/compare/github:master...templaedhel:userforid-reconciliation?expand=1#diff-3f212f83b49bd9f3b418259c1f06c0cfL109). 
### The Fix

I removed all the logic around if and when to update users in the brain. Now `userForId` will always return the user for the given ID, as well as updating it with any additional attributes passed in. 

This fixes our issue. 
### Several Questions Remain
- Is there a reason behind the complicated logic around only updating if `options.room` isn't set on the existing user? Tracing back through git didn't dig up anything interesting. I also have trouble seeing how these changes will break any logical uses of this function
