### PR TITLE
Parse help for scripts in external-scripts.json

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -254,6 +254,7 @@ class Robot
       if packages instanceof Array
         for pkg in packages
           require(pkg)(@)
+          @parseHelp pkg if Fs.existsSync pkg
       else
         for pkg, scripts of packages
           require(pkg)(@, scripts)


### PR DESCRIPTION
If you provide a path to script in `external-scripts.json`, script gets loaded, but it's documentation does not get parsed. This fixes the issue.
