### PR TITLE
Prefer rediscloud over redistogo for heroku

### DIFF
--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -65,7 +65,7 @@ before:
 
     % git commit -am "Awesome scripts OMG"
     % git push heroku master
-    
-Some scripts needs Redis to work, Heroku offers an addon called [RedisToGo](https://addons.heroku.com/RedisToGo), which has a free nano plan. To use it:
 
-    % heroku addons:add redistogo:nano
+Some scripts needs Redis to work, Heroku offers an addon called [Redis Cloud](https://addons.heroku.com/rediscloud), which has a free plan. To use it:
+
+    % heroku addons:add rediscloud


### PR DESCRIPTION
I was reading over the docs as I was setting up a new bot, and noticed that the redistogo's nano plan doesn't include persistence. All of Redis Cloud's plans (including free) include persistence, so that should be the go to so the brain persistence actually works.
