### PR TITLE
Respond to 'who has admin role' query even if the only admin is the issuer

### DIFF
--- a/src/scripts/auth.coffee
+++ b/src/scripts/auth.coffee
@@ -117,5 +117,7 @@ module.exports = (robot) ->
 
     if adminNames.length > 0
       msg.reply "The following people have the 'admin' role: #{adminNames.join(', ')}"
+    else if robot.auth.hasRole(msg.envelope.user,'admin')
+      msg.reply "Looks like you're the only admin!"
     else
       msg.reply "There are no people that have the 'admin' role."


### PR DESCRIPTION
The "who has admin role" query will now respond with
"Looks like you're the only admin!" if the person issuing
the query is the only admin.

Previously, the response would be "no admins".
