### PR TITLE
Add documentation on sending back a response within an HTTP listener

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -410,11 +410,13 @@ The most common use of this is for providing HTTP end points for services with w
 ```coffeescript
 module.exports = (robot) ->
   robot.router.post '/hubot/chatsecrets/:room', (req, res) ->
-    room = req.params.room
-    data = JSON.parse req.body.payload
+    room   = req.params.room
+    data   = JSON.parse req.body.payload
     secret = data.secret
 
     robot.messageRoom room, "I have a secret: #{secret}"
+
+    res.send 'OK'
 ```
 
 ## Events


### PR DESCRIPTION
I recently tried to setup a webhook integration with a Hubot script and discovered (after some debugging) that a default response is not sent back to the client within an HTTP listener.

Would be nice to add a little documentation on how to send back a response and a link to further reading in the NodeJS docs.
