### PR TITLE
Add a toString to TextMessage so log messages are meaningful

### DIFF
--- a/src/message.coffee
+++ b/src/message.coffee
@@ -27,6 +27,12 @@ class TextMessage extends Message
   # Returns a Match object or null.
   match: (regex) ->
     @text.match regex
+  
+  # String representation of a TextMessage
+  #
+  # Returns the message text
+  toString: () ->
+    @text
 
 # Represents an incoming user entrance notification.
 #


### PR DESCRIPTION
Ex:
DEBUG Message '[object Object]' matched regex //^[@]?Hubot[:,]?\s_(?:PING$)/i/
becomes:
DEBUG Message 'hubot ping' matched regex //^[@]?Hubot[:,]?\s_(?:PING$)/i/
