### PR TITLE
Campfire Adapter User-Agent

### DIFF
--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -257,6 +257,7 @@ class CampfireStreaming extends EventEmitter
       "Authorization" : @authorization
       "Host"          : @host
       "Content-Type"  : "application/json"
+      "User-Agent"    : "Hubot/#{@robot.version} (#{@robot.name})"
 
     options =
       "agent"  : false


### PR DESCRIPTION
Not specifying a User-Agent is usually in poor form. It's also a good way to get rate limited hard. Let's be nice :sparkling_heart: 
