### PR TITLE
Campfire Adapter User Agent: Guard against nil robot

### DIFF
--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -182,7 +182,7 @@ class CampfireStreaming extends EventEmitter
       headers =
         "Host"          : "streaming.campfirenow.com"
         "Authorization" : self.authorization
-        "User-Agent"    : "Hubot/#{@robot.version} (#{@robot.name})"
+        "User-Agent"    : "Hubot/#{@robot?.version} (#{@robot?.name})"
 
       options =
         "agent"  : false
@@ -257,7 +257,7 @@ class CampfireStreaming extends EventEmitter
       "Authorization" : @authorization
       "Host"          : @host
       "Content-Type"  : "application/json"
-      "User-Agent"    : "Hubot/#{@robot.version} (#{@robot.name})"
+      "User-Agent"    : "Hubot/#{@robot?.version} (#{@robot?.name})"
 
     options =
       "agent"  : false


### PR DESCRIPTION
Testing this, saw that sometimes `@robot` was nil, which would raise a bunch of exceptions
