### PR TITLE
Removed #.png ending to image urls if image file ending already exists

### DIFF
--- a/src/scripts/google-images.coffee
+++ b/src/scripts/google-images.coffee
@@ -39,6 +39,12 @@ imageMe = (msg, query, animated, faces, cb) ->
       images = JSON.parse(body)
       images = images.responseData?.results
       if images?.length > 0
-        image  = msg.random images
-        cb "#{image.unescapedUrl}#.png"
+        image = msg.random images
+        cb ensureImageExtension image.unescapedUrl
 
+ensureImageExtension = (url) ->
+  ext = url.split('.').pop()
+  if /(png|jpe?g|gif)/i.test(ext)
+    url
+  else
+    "#{url}#.png"


### PR DESCRIPTION
Removed the #.png which was put in the ending of image urls. 
Used to get urls like: http://www.dating-tips-that-coach-women.com/image-files/men-test-women.jpg#.png
Now we get: http://www.dating-tips-that-coach-women.com/image-files/men-test-women.jpg
