### PR TITLE
Fix help command replaces prefix twice

### DIFF
--- a/src/scripts/help.coffee
+++ b/src/scripts/help.coffee
@@ -66,8 +66,8 @@ module.exports = (robot) ->
 
     prefix = robot.alias or robot.name
     cmds = cmds.map (cmd) ->
-      cmd = cmd.replace /^hubot/, prefix
-      cmd.replace /hubot/ig, robot.name
+      cmd = cmd.replace /hubot/ig, robot.name
+      cmd.replace new RegExp("^#{robot.name}"), prefix
 
     emit = cmds.join "\n"
 


### PR DESCRIPTION
Hi,

I fixed `hubot help` command replaces prefix twice if the Robot has custom name.

In case `HUBOT_NAME=MyHubot`:

```
MyMyHubot help - Displays all of the help commands that MyHubot knows about.
```

I fixed it to

```
MyHubot help - Displays all of the help commands that MyHubot knows about.
```
