### PR TITLE
changes to robot.coffee to invalidate require cache on loadfile.

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -211,6 +211,13 @@ class Robot
   loadFile: (path, file) ->
     ext  = Path.extname file
     full = Path.join path, Path.basename(file, ext)
+    if  require.cache[require.resolve(full)]
+      try
+        cacheobj = require.resolve(full)
+        @logger.debug "require cache for #{cacheobj} invalidated."
+        delete require.cache[cacheobj]
+      catch error
+        @logger.error "Unable to invalidate #{cacheobj}: #{error.stack}"
     if require.extensions[ext]
       try
         require(full) @


### PR DESCRIPTION
This change adds a require.cache invalidate to robot.coffee's loadfile function. With this addition, reloading scripts becomes possible (through reload.coffee or script.coffee) without restarting the hubot process. 
