### PR TITLE
improve static path setup

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -281,6 +281,7 @@ class Robot
     app.use express.query()
     app.use express.bodyParser()
     app.use express.static stat if stat
+    app.use express.static Path.normalize("#{__dirname}/#{stat}") if stat
 
     try
       @server = app.listen(process.env.PORT || 8080, process.env.BIND_ADDRESS || '0.0.0.0')


### PR DESCRIPTION
This allows for scripts installed via npm to make use of their own static paths (.e.g `.../hubot/node_modules/hubot-somescript/src/public`)

Specify the `EXPRESS_STATIC` env var like `EXPRESS_STATIC=../node_modules/hubot-module/src/public` when serving static files from a hubot script.
