### PR TITLE
Make use of HUBOT_PATH env variable when loading scripts

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -81,26 +81,26 @@ else
   robot.alias = Options.alias
 
   loadScripts = ->
-    scriptsPath = Path.resolve ".", "scripts"
+    scriptsPath = Path.resolve Options.path, "scripts"
     robot.load scriptsPath
 
-    scriptsPath = Path.resolve ".", "src", "scripts"
+    scriptsPath = Path.resolve Options.path, "src", "scripts"
     robot.load scriptsPath
 
-    hubotScripts = Path.resolve ".", "hubot-scripts.json"
+    hubotScripts = Path.resolve Options.path, "hubot-scripts.json"
     Fs.exists hubotScripts, (exists) ->
       if exists
         Fs.readFile hubotScripts, (err, data) ->
           if data.length > 0
             try
               scripts = JSON.parse data
-              scriptsPath = Path.resolve "node_modules", "hubot-scripts", "src", "scripts"
+              scriptsPath = Path.resolve Options.path, "node_modules", "hubot-scripts", "src", "scripts"
               robot.loadHubotScripts scriptsPath, scripts
             catch err
               console.error "Error parsing JSON data from hubot-scripts.json: #{err}"
               process.exit(1)
 
-    externalScripts = Path.resolve ".", "external-scripts.json"
+    externalScripts = Path.resolve Options.path, "external-scripts.json"
     Fs.exists externalScripts, (exists) ->
       if exists
         Fs.readFile externalScripts, (err, data) ->
@@ -116,7 +116,7 @@ else
       if path[0] == '/'
         scriptsPath = path
       else
-        scriptsPath = Path.resolve ".", path
+        scriptsPath = Path.resolve Options.path, path
       robot.load scriptsPath
 
   robot.adapter.on 'connected', loadScripts


### PR DESCRIPTION
Currently, you have to be in a proper working directory to launch Hubot. At the same time, we have defined HUBOT_PATH we are almost not using at all.

After that patch, you would be able to execute Hubot from any directory by providing proper HUBOT_PATH:

``` sh
BASEDIR=path/to/bot

npm install --prefix $BASEDIR

env HUBOT_PATH="$BASEDIR" $BASEDIR/node_modules/.bin/hubot
```
