### PR TITLE
Adding `hubot-gitter2` to the list of adapters

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -34,6 +34,7 @@ to have yours added to the list:
 * [AIM](https://github.com/shaundubuque/hubot-aim)
 * [Slack](https://github.com/tinyspeck/hubot-slack)
 * [Lingr](https://github.com/miyagawa/hubot-lingr)
+* [Gitter](https://github.com/huafu/hubot-gitter2)
 
 ## Writing Your Own adapter
 


### PR DESCRIPTION
As mentioned by @technicalpickles in #740 here is the addition of `Gitter` adapter to the list
