### PR TITLE
Change string encoding function from escape to encodeURIComponent

### DIFF
--- a/src/scripts/maps.coffee
+++ b/src/scripts/maps.coffee
@@ -10,15 +10,15 @@ module.exports = (robot) ->
     mapType  = msg.match[1] or "roadmap"
     location = msg.match[2]
     mapUrl   = "http://maps.google.com/maps/api/staticmap?markers=" +
-                escape(location) +
+                encodeURIComponent(location) +
                 "&size=400x400&maptype=" +
                 mapType +
                 "&sensor=false" +
                 "&format=png" # So campfire knows it's an image
     url      = "http://maps.google.com/maps?q=" +
-               escape(location) +
+               encodeURIComponent(location) +
               "&hl=en&sll=37.0625,-95.677068&sspn=73.579623,100.371094&vpsrc=0&hnear=" +
-              escape(location) +
+              encodeURIComponent(location) +
               "&t=m&z=11"
 
     msg.send mapUrl


### PR DESCRIPTION
Change string encoding function from escape to encodeURIComponent.
Because the encode function could not multibyte string for URI.
