### PR TITLE
Add metadata field to TextMessage

### DIFF
--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -69,7 +69,7 @@ class Campfire extends Adapter
     bot.on "TextMessage",
       withAuthor (id, created, room, user, body, author) ->
         unless bot.info.id is author.id
-          message = new TextMessage author, body, id
+          message = new TextMessage author, body, id, room: room
           message.private = bot.private[room]
           self.receive message
 

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -17,7 +17,8 @@ class TextMessage extends Message
   # user - A User instance that sent the message.
   # text - A String message.
   # id   - A String of the message ID.
-  constructor: (@user, @text, @id) ->
+  # data - Additional metadata about the message, like room or thread info
+  constructor: (@user, @text, @id, @metadata = {}) ->
     super @user
 
   # Determines if the message matches the given regex.
@@ -27,7 +28,7 @@ class TextMessage extends Message
   # Returns a Match object or null.
   match: (regex) ->
     @text.match regex
-  
+
   # String representation of a TextMessage
   #
   # Returns the message text

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -2,8 +2,8 @@ class Message
   # Represents an incoming message from the chat.
   #
   # user - A User instance that sent the message.
-  constructor: (@user, @done = false) ->
-    @room = @user.room
+  constructor: (@user, @done = false, @envelope = {}) ->
+    @room = @envelope.room ? @user.room
 
   # Indicates that no other Listener should be called on this object
   #
@@ -14,12 +14,12 @@ class Message
 class TextMessage extends Message
   # Represents an incoming message from the chat.
   #
-  # user - A User instance that sent the message.
-  # text - A String message.
-  # id   - A String of the message ID.
-  # data - Additional metadata about the message, like room or thread info
-  constructor: (@user, @text, @id, @metadata = {}) ->
-    super @user
+  # user     - A User instance that sent the message.
+  # text     - A String message.
+  # id       - A String of the message ID.
+  # envelope - Additional metadata about the message, like room or thread info
+  constructor: (@user, @text, @id, envelope = {}) ->
+    super @user, undefined, envelope
 
   # Determines if the message matches the given regex.
   #

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -11,6 +11,7 @@ class Response
       room: @message.room
       user: @message.user
       message: @message
+      metadata: @message.metadata
 
   # Public: Posts a message back to the chat source
   #

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -11,7 +11,8 @@ class Response
       room: @message.room
       user: @message.user
       message: @message
-      metadata: @message.metadata
+    for own k,v of @message.envelope
+      @envelope[k] = v
 
   # Public: Posts a message back to the chat source
   #


### PR DESCRIPTION
Hubot does not really support any kind of metadata for messages, and even the room support is hacky, since the value is stored in the author (which is actually an instance of user that is stored in the brain). Flowdock adapter also needs to be able to pass other data along with the message, like threading information. Adding all this to the author feels like it's just the wrong place.

I'd like to add a `metadata` field to `TextMessage` so that modifying author could be deprecated and room/thread etc info could be passed in that object. I could do that for just flowdock-adapter, but I'd like the pattern to be officially supported so that other script authors could use that. I created an issue for hubot-flowdock too https://github.com/flowdock/hubot-flowdock/issues/52 and this is a requirement for that to be solved properly.

Any thoughts?
