### PR TITLE
Fix Heroku dyno command

### DIFF
--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -102,7 +102,7 @@ name as a double quoted string to the `external-scripts.json` file in this repo.
 
     % heroku create --stack cedar
     % git push heroku master
-    % heroku ps:scale app=1
+    % heroku ps:scale web=1
 
 If your Heroku account has been verified you can run the following to enable
 and add the Redis to Go addon to your app.


### PR DESCRIPTION
Got this error while running: $ heroku ps:scale app=1
Scaling dynos... failed
 !    No such process type app defined in Procfile.

So, I fixed the command to work with your Procfile :) But in actuality, I didn't need to run the dyno command since the web dyno was 1 after "git push heroku master" completes for me. But it never hurts to be explicit when sending Heroku commands.
