### PR TITLE
Remove Heroku dyno activation command

### DIFF
--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -102,7 +102,6 @@ name as a double quoted string to the `external-scripts.json` file in this repo.
 
     % heroku create --stack cedar
     % git push heroku master
-    % heroku ps:scale app=1
 
 If your Heroku account has been verified you can run the following to enable
 and add the Redis to Go addon to your app.


### PR DESCRIPTION
When I do "git push heroku master", Heroku reads the Procfile and activates a web 1X dyno automatically. Therefore, this line is not required.

Output of "heroku ps" right after "git push heroku master":
=== web (1X): `bin/hubot -a campfire -n Hubot`
web.1: restarting 2014/10/15 22:52:28 (~ 0s ago)

I previously (2 days ago) received this error when running "heroku ps:scale app=1":
Scaling dynos... failed
! No such process type app defined in Procfile.

Today, I downloaded a clone of this repo, deployed this template to Heroku by following the instructions, but disregarding "heroku ps:scale app=1", and it ran fine, so it is verified that the line I'm proposing to be removed should be removed.

This is in response to:
https://github.com/github/hubot/pull/789

So, feel free to disregard my other pull request if you find this one to be better :)
