### PR TITLE
Ensure that User#name is always a string

### DIFF
--- a/src/user.coffee
+++ b/src/user.coffee
@@ -6,6 +6,6 @@ class User
   constructor: (@id, options = {}) ->
     for k of (options or {})
       @[k] = options[k]
-    @['name'] ||= @id
+    @['name'] ||= @id.toString()
 
 module.exports = User

--- a/test/brain_test.coffee
+++ b/test/brain_test.coffee
@@ -26,3 +26,7 @@ setTimeout ->
   assert.ok saved
   assert.ok closed
 , 200
+
+user = brain.userForId 9876
+assert.strictEqual 9876, user.id
+assert.strictEqual "9876", user.name

--- a/test/user_test.coffee
+++ b/test/user_test.coffee
@@ -12,3 +12,7 @@ assert.equal "Fake User", user.id
 assert.equal "chat@room.jabber", user.room
 assert.equal "groupchat", user.type
 assert.equal "Fake User", user.name # Make sure that if no name is given, we fallback to the ID
+
+user = new User 12345
+assert.strictEqual 12345, user.id
+assert.strictEqual "12345", user.name


### PR DESCRIPTION
User uses its ID as its name by default. In Campfire, user IDs are Numbers, so if we aren't careful we can end up with `User#name` being a Number too. This can trip up code that is expecting a String.

/cc @technicalpickles @bhuga @keithduncan 
