### PR TITLE
Allow preceding whitespace for robot.respond

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -101,12 +101,12 @@ class Robot
     if @alias
       alias = @alias.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
       newRegex = new RegExp(
-        "^[@]?(?:#{alias}[:,]?|#{name}[:,]?)\\s*(?:#{pattern})"
+        "^\\s*[@]?(?:#{alias}[:,]?|#{name}[:,]?)\\s*(?:#{pattern})"
         modifiers
       )
     else
       newRegex = new RegExp(
-        "^[@]?#{name}[:,]?\\s*(?:#{pattern})",
+        "^\\s*[@]?#{name}[:,]?\\s*(?:#{pattern})",
         modifiers
       )
 


### PR DESCRIPTION
Sometimes when copying and pasting hubot commands, one might unintentionally
introduce whitespace before the hubot's name. This commit allows the robot
to respond even if the name is prefixed by an arbitrary amount of whitespace.

We ran into this problem at Meraki when copying and pasting commands that were sent out of an automated email. We've tested this locally in our hubot instance, and it seems to work fine.
