### PR TITLE
Fix bug where @pingIntervalId is not being held

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -48,13 +48,13 @@ class Robot
     @commands  = []
     @listeners = []
     @logger    = new Log process.env.HUBOT_LOG_LEVEL or 'info'
+    @pingIntervalId = null
 
     @parseVersion()
     if httpd
       @setupExpress()
     else
       @setupNullRouter()
-    @pingIntervalId = null
 
     @loadAdapter adapterPath, adapter
 


### PR DESCRIPTION
setupExpress() assigns @pingIntervalId but then it is being reset to null
right after.
