### PR TITLE
Version bump to 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.9.0
+======
+
+* Deprecate `hubot --create` in favor of new yeoman generator
+
 v2.8.3
 ======
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot",
-  "version": "2.8.3",
+  "version": "2.9.0",
 
   "author": "hubot",
 


### PR DESCRIPTION
Just includes https://github.com/github/hubot/pull/764 .

Went with minor release, as it's 'new' functionality, but retains the `--create` flag still, albeit warning to replace it. 
