### PR TITLE
Fix incorrect config check option in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ v2.8.1
 v2.8.0
 ======
 
-* Add support for `hubot --check-config` to verify hubot will load based on how it's configured
+* Add support for `hubot --config-check` to verify hubot will load based on how it's configured
 * Include `script/` directory for convenient one-liners for common tasks of developing github/hubot
 * Fixes to default `image me` and `help`
 * Updated documentation about external scripts


### PR DESCRIPTION
It's not a high priority problem, it's just a _typo_ in the documentation.

`--check-config` doesn't seem to exist. It is `--config-check` according to the source.
