### PR TITLE
Update Express

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "optparse":           "1.0.4",
     "scoped-http-client": "0.9.8",
     "log":                "1.4.0",
-    "express":            "3.3.4"
+    "express":            "3.18.1"
   },
 
   "engines": {


### PR DESCRIPTION
Update Express to the latest 3.x version due to this http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-7191

This should suffice until Express is fully removed.
