### PR TITLE
Version bump to 2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v2.9.2
+======
+
+* Update express dependency to a version isn't affected by [CVE-2014-7191](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-7191)
+   * More specifically, a version of express that depends on connect that depends on qs that isn't vulnerable
+
 v2.9.1
 ======
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot",
-  "version": "2.9.1",
+  "version": "2.9.2",
 
   "author": "hubot",
 


### PR DESCRIPTION
Primarily includes https://github.com/github/hubot/pull/806 for addressing a security vulnerability in express's dependency's dependency.
