### PR TITLE
Reduce heroku ping interval down to 5 minutes (from 20)

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -297,7 +297,7 @@ class Robot
       @pingIntervalId = setInterval =>
         HttpClient.create("#{herokuUrl}hubot/ping").post() (err, res, body) =>
           @logger.info 'keep alive ping!'
-      , 1200000
+      , 5 * 60 * 1000
 
   # Setup an empty router object
   #


### PR DESCRIPTION
This should address https://github.com/github/hubot/issues/779

The end goal is going to be having people use https://github.com/hubot-scripts/hubot-heroku-keepalive  , but this should get the fix out to as many people as possible.
