### PR TITLE
Version bump to 2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v2.9.3
+======
+
+* Allow `robot.respond` to work when there is preceding whitespace
+* Update `robot.parseHelp` to be synchronous, so it's easier to test
+* Reduce Heroku ping interval from 20 minutes to 5 minutes to keep hubot from going unavailable
+* Make sure`robot.pingIntervalId` is kept after setting up Heroku ping  interval
+
 v2.9.2
 ======
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot",
-  "version": "2.9.2",
+  "version": "2.9.3",
 
   "author": "hubot",
 


### PR DESCRIPTION
Includes:
- Make sure`robot.pingIntervalId` is kept after setting up Heroku ping  interval cc https://github.com/github/hubot/pull/795 @DexterV
- Allow `robot.respond` to work when there is preceding whitespace cc https://github.com/github/hubot/pull/794 @ahayworth 
- Update `robot.parseHelp` to be synchronous, so it's easier to test cc https://github.com/github/hubot/pull/762 @bouzuya 
- Reduce Heroku ping interval from 20 minutes to 5 minutes to keep hubot from going unavailable cc https://github.com/github/hubot/pull/809
