### PR TITLE
Update scripting.md script package sample

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -585,16 +585,11 @@ will use to load the scripts in your package. Below is a simple example for
 loading each script in a `./scripts` directory in your package.
 
 ```coffeescript
-Fs   = require 'fs'
 Path = require 'path'
 
 module.exports = (robot) ->
   path = Path.resolve __dirname, 'scripts'
-  Fs.exists path, (exists) ->
-    if exists
-      for file in Fs.readdirSync(path)
-        robot.loadFile path, file
-        robot.parseHelp Path.join(path, file)
+  robot.load path
 ```
 
 After you've built your `npm` package you can publish it to [npmjs](http://npmjs.org).


### PR DESCRIPTION
Update the sample code for "Creating A Script Package" to use
`robot.load`. Previously it was duplicating the `exists`/`readdir` logic
that `robot.load` already has, except it was doing the exists check
asynchronously, which changes script load order and also means the
script won't have loaded in time when using the `--config-check` flag.
