### PR TITLE
Handle a script not exporting a function

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -220,7 +220,7 @@ class Robot
           script @
           @parseHelp Path.join(path, file)
         else
-          @logger.warning "Expected #{full} to assign a function to module.exports, not #{typeof script}"
+          @logger.warning "Expected #{full} to assign a function to module.exports, got #{typeof script}"
 
       catch error
         @logger.error "Unable to load #{full}: #{error.stack}"


### PR DESCRIPTION
Previously, if you omitted `modules.export = (robot) ->`, or assigned it to anything that's not a function, you'd get an error as described in https://github.com/github/hubot/issues/829 

```
2014-12-10T10:43:38.554340+00:00 app[web.1]: [Wed Dec 10 2014 10:43:38 GMT+0000 (UTC)] ERROR Unable to load /app/scripts/frokost: TypeError: object is not a function
2014-12-10T10:43:38.554347+00:00 app[web.1]:   at Robot.loadFile (/app/node_modules/hubot/src/robot.coffee:217:9, <js>:163:24)
2014-12-10T10:43:38.554349+00:00 app[web.1]:   at Robot.load (/app/node_modules/hubot/src/robot.coffee:233:9, <js>:181:30)
2014-12-10T10:43:38.554353+00:00 app[web.1]:   at HipChat.emit (events.js:92:17)
2014-12-10T10:43:38.554355+00:00 app[web.1]:   at Connector.<anonymous> (/app/node_modules/hubot-hipchat/src/hipchat.js:135:13)
2014-12-10T10:43:38.554356+00:00 app[web.1]:   at Connector.emit (events.js:117:20)
```

This updates hubot to check the `typeof` the required script, and only call it if it's a function. Otherwise, log a warning and continue on.

cc @lajlev @MrSaints as participants on https://github.com/github/hubot/issues/829 
