### PR TITLE
Update require('hubot') to also export Message in addition to its subclasses

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -4,7 +4,7 @@ Robot                                                                = require '
 Adapter                                                              = require './src/adapter'
 Response                                                             = require './src/response'
 {Listener,TextListener}                                              = require './src/listener'
-{TextMessage,EnterMessage,LeaveMessage,TopicMessage,CatchAllMessage} = require './src/message'
+{Message,TextMessage,EnterMessage,LeaveMessage,TopicMessage,CatchAllMessage} = require './src/message'
 
 module.exports = {
   User
@@ -14,6 +14,7 @@ module.exports = {
   Response
   Listener
   TextListener
+  Message
   TextMessage
   EnterMessage
   LeaveMessage


### PR DESCRIPTION
This implements the feature request in https://github.com/github/hubot/issues/834 :

> Hubot exports all of the Message subclasses, but it doesn't export Message itself. It should be exported to allow adapters to create new message types that scripts could look for (e.g. a message that represents some event Hubot doesn't model).

cc @kballard https://github.com/slackhq/hubot-slack/pull/133
