### PR TITLE
Add robot.catchAllAddressed

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -472,6 +472,22 @@ Using previous examples:
 
 For the second example, it's worth thinking about what messages the user would see. If you have an error handler that replies to the user, you may not need to add a custom message and could send back the error message provided to the `get()` request, but of course it depends on how public you want to be with your exception reporting.
 
+## Catch All
+
+Sometimes you are interested in responding to all unmatched messages in a room. Hubot has two helpers to generate listeners that will only react when all other listeners have been tested.
+
+`catchAll` will respond to ALL messages that weren't matched by a non-catch-all listener (e.g. `I would like a sandwich today`)
+
+`catchAllAddressed` will only respond to catch-all messages that were addressed to the robot (e.g. `Hubot: tell me a story`)
+
+`catchAllAddressed` is particularly useful if you would like to have your robot apologize:
+
+```coffeescript
+module.exports = (robot) ->
+  robot.catchAllAddressed (response) ->
+    response.reply "I'm sorry, I don't know how to \"#{response.match[1]}\"... :sob:"
+```
+
 ## Documenting Scripts
 
 Hubot scripts can be documented with comments at the top of their file, for example:

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -217,6 +217,24 @@ class Robot
       ((msg) -> msg.message = msg.message.message; callback msg)
     )
 
+  # Public: Adds a Listener that triggers when no other text matchers match
+  # and the message was addressing the robot.
+  #
+  # callback - A Function that is called with a Response object.
+  #
+  # Returns nothing.
+  catchAllAddressed: (callback) ->
+    pattern = @respondPattern(/(.*)/)
+    @listeners.push new Listener(
+      @
+      (msg) ->
+        if msg instanceof CatchAllMessage and msg.message.match?
+          msg.message.match(pattern)
+      (response) ->
+        response.message = response.message.message
+        callback response
+    )
+
   # Public: Passes the given message to any interested Listeners.
   #
   # message - A Message instance. Listeners can flag this message as 'done' to

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -171,6 +171,12 @@ describe 'Robot', ->
         @robot.catchAll ->
         expect(@robot.listeners).to.have.length(1)
 
+    describe '#catchAllAddressed', ->
+      it 'registers a new Listener', ->
+        expect(@robot.listeners).to.have.length(0)
+        @robot.catchAllAddressed ->
+        expect(@robot.listeners).to.have.length(1)
+
     describe '#receive', ->
       it 'calls all registered listeners', ->
         # Need to use a real Message so that the CatchAllMessage constructor works
@@ -461,6 +467,47 @@ describe 'Robot', ->
         result = testListener.matcher(testMessage)
 
         expect(result).to.not.be.ok
+
+      it 'matches CatchAllMessages wrapping non-TextMessages', ->
+        @robot.catchAll ->
+        # Grab the only registered listener
+        testListener = @robot.listeners[0]
+
+        testMessage = new CatchAllMessage(new EnterMessage @user)
+        expect(testListener.matcher(testMessage)).to.be.ok
+
+    describe '#catchAllAddressed', ->
+      it 'matches messages addressed to the robot', ->
+        @robot.catchAllAddressed ->
+        # Grab the only registered listener
+        testListener = @robot.listeners[0]
+
+        testMessage = new CatchAllMessage(new TextMessage @user, 'TestHubot: message123')
+        expect(testListener.matcher(testMessage)).to.be.ok
+
+      it 'does not match messages not addressed to the robot', ->
+        @robot.catchAllAddressed ->
+        # Grab the only registered listener
+        testListener = @robot.listeners[0]
+
+        testMessage = new CatchAllMessage(new TextMessage @user, 'message123')
+        expect(testListener.matcher(testMessage)).to.not.be.ok
+
+      it 'does not match non-CatchAllMessages that are addressed to the robot', ->
+        @robot.catchAllAddressed ->
+        # Grab the only registered listener
+        testListener = @robot.listeners[0]
+
+        testMessage = new TextMessage @user, 'TestHubot: message123'
+        expect(testListener.matcher(testMessage)).to.not.be.ok
+
+      it 'does not match CatchAllMessages wrapping non-TextMessages', ->
+        @robot.catchAllAddressed ->
+        # Grab the only registered listener
+        testListener = @robot.listeners[0]
+
+        testMessage = new CatchAllMessage(new EnterMessage @user)
+        expect(testListener.matcher(testMessage)).to.not.be.ok
 
   describe 'Message Processing', ->
     it 'calls a matching listener', (done) ->


### PR DESCRIPTION
Closes #683

Adds a new listener type that responds to messages that were addressed to the robot and didn't match any other (non-catch-all) listeners. More details in the docs.
