### PR TITLE
Add Robot#eavesdrop

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -287,6 +287,18 @@ module.exports = (robot) ->
     res.send res.random leaveReplies
 ```
 
+## Eavesdrop
+
+Hubot can match 'anti-respond' messages: messages that are specifically *not* addressed to the robot.
+
+```coffeescript
+module.exports = (robot) ->
+  robot.eavesdrop /hello/, (msg) ->
+    # This will match "hello", but not "Hubot: hello"
+  robot.respond /hello/, (msg) ->
+    # This will match "Hubot: hello", but not "hello"
+```
+
 ## Custom Listeners
 
 While the above helpers cover most of the functionality the average user needs (hear, respond, enter, leave, topic), sometimes you would like to have very specialized matching logic for listeners. If so, you can use `listen` to specify a custom match function instead of a regular expression.

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -160,6 +160,12 @@ describe 'Robot', ->
         @robot.respond /.*/, ->
         expect(@robot.hear).to.have.been.called
 
+    describe '#eavesdrop', ->
+      it 'registers a new listener', ->
+        sinon.spy @robot, 'listen'
+        @robot.eavesdrop /.*/, ->
+        expect(@robot.listen).to.have.been.called
+
     describe '#enter', ->
       it 'registers a new listener using listen', ->
         sinon.spy @robot, 'listen'
@@ -409,6 +415,40 @@ describe 'Robot', ->
         testRegex = /.*/
 
         @robot.respond(testRegex, callback)
+        testListener = @robot.listeners[0]
+        result = testListener.matcher(testMessage)
+
+        expect(result).to.not.be.ok
+
+    describe '#eavesdrop', ->
+      it 'matches TextMessages not addressed to the robot', ->
+        callback = sinon.spy()
+        testMessage = new TextMessage(@user, 'message123')
+        testRegex = /message123/
+
+        @robot.eavesdrop(testRegex, callback)
+        testListener = @robot.listeners[0]
+        result = testListener.matcher(testMessage)
+
+        expect(result).to.be.ok
+
+      it 'does not match TextMessages addressed to the robot', ->
+        callback = sinon.spy()
+        testMessage = new TextMessage(@user, 'TestHubot message123')
+        testRegex = /message123/
+
+        @robot.eavesdrop(testRegex, callback)
+        testListener = @robot.listeners[0]
+        result = testListener.matcher(testMessage)
+
+        expect(result).to.not.be.ok
+
+      it 'does not match EnterMessages', ->
+        callback = sinon.spy()
+        testMessage = new EnterMessage(@user)
+        testRegex = /.*/
+
+        @robot.eavesdrop(testRegex, callback)
         testListener = @robot.listeners[0]
         result = testListener.matcher(testMessage)
 


### PR DESCRIPTION
Lots of new tests and refactoring to eventually add Robot#eavesdrop and fix #866.

Each commit should be able to stand alone (all tests passing), refactor commits don't touch code and tests at the same time, and new tests were added first to cover all areas being modified.

`TextListener` was removed in favor of a common pattern of putting all matcher logic in Robot instead of some in Robot and some in a subclass of Listener.

This also introduces Robot#listen as a new public method.
