### PR TITLE
added robot.once function, wrapper for events.once

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -437,6 +437,17 @@ class Robot
   # Public: A wrapper around the EventEmitter API to make usage
   # semanticly better.
   #
+  # event    - The event name.
+  # listener - A Function that is called with the event parameter
+  #            when first event happens.
+  #
+  # Returns nothing.
+  once: (event, args...) ->
+    @events.once event, args...
+
+  # Public: A wrapper around the EventEmitter API to make usage
+  # semanticly better.
+  #
   # event   - The event name.
   # args...  - Arguments emitted by the event
   #


### PR DESCRIPTION
I have added `robot.once` function.

[events.once](https://nodejs.org/api/events.html#events_emitter_once_event_listener) is useful for handling one time event.
It is available at [node v0.3.0](https://nodejs.org/docs/v0.3.0/api.html)
