### PR TITLE
Change instanceof to respect interfaces

### DIFF
--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -57,7 +57,7 @@ class TextListener extends Listener
   # callback - A Function that is triggered if the incoming message matches.
   constructor: (@robot, @regex, @options, @callback) ->
     @matcher = (message) =>
-      if message.type == 'text'
+      if message.type is 'text'
         message.match @regex
     super @robot, @matcher, @options, @callback
 

--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -57,7 +57,7 @@ class TextListener extends Listener
   # callback - A Function that is triggered if the incoming message matches.
   constructor: (@robot, @regex, @options, @callback) ->
     @matcher = (message) =>
-      if message.match
+      if message.type == 'text'
         message.match @regex
     super @robot, @matcher, @options, @callback
 

--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -57,7 +57,7 @@ class TextListener extends Listener
   # callback - A Function that is triggered if the incoming message matches.
   constructor: (@robot, @regex, @options, @callback) ->
     @matcher = (message) =>
-      if message instanceof TextMessage
+      if message.match
         message.match @regex
     super @robot, @matcher, @options, @callback
 

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -63,7 +63,7 @@ class TopicMessage extends TextMessage
   type: 'topic'
 
 class CatchAllMessage extends Message
-  type: 'all'
+  type: 'catchall'
 
   # Represents a message that no matchers matched.
   #

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -1,4 +1,6 @@
 class Message
+  type: 'message'
+
   # Represents an incoming message from the chat.
   #
   # user - A User instance that sent the message.
@@ -12,6 +14,8 @@ class Message
     @done = true
 
 class TextMessage extends Message
+  type: 'text'
+
   # Represents an incoming message from the chat.
   #
   # user - A User instance that sent the message.
@@ -27,7 +31,7 @@ class TextMessage extends Message
   # Returns a Match object or null.
   match: (regex) ->
     @text.match regex
-  
+
   # String representation of a TextMessage
   #
   # Returns the message text
@@ -40,6 +44,7 @@ class TextMessage extends Message
 # text - Always null.
 # id   - A String of the message ID.
 class EnterMessage extends Message
+  type: 'enter'
 
 # Represents an incoming user exit notification.
 #
@@ -47,6 +52,7 @@ class EnterMessage extends Message
 # text - Always null.
 # id   - A String of the message ID.
 class LeaveMessage extends Message
+  type: 'leave'
 
 # Represents an incoming topic change notification.
 #
@@ -54,8 +60,11 @@ class LeaveMessage extends Message
 # text - A String of the new topic
 # id   - A String of the message ID.
 class TopicMessage extends TextMessage
+  type: 'topic'
 
 class CatchAllMessage extends Message
+  type: 'all'
+
   # Represents a message that no matchers matched.
   #
   # message - The original message.

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -212,7 +212,7 @@ class Robot
 
     @listeners.push new Listener(
       @,
-      ((msg) -> msg.type is 'all'),
+      ((msg) -> msg.type is 'catchall'),
       options,
       ((msg) -> msg.message = msg.message.message; callback msg)
     )
@@ -233,7 +233,7 @@ class Robot
         @emit('error', error, new @Response(@, message, []))
 
         false
-    if message.type isnt 'all' and results.indexOf(true) is -1
+    if message.type isnt 'catchall' and results.indexOf(true) is -1
       @receive new CatchAllMessage(message)
 
   # Public: Loads a file in path.

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -137,7 +137,7 @@ class Robot
   enter: (options, callback) ->
     @listeners.push new Listener(
       @,
-      ((msg) -> msg instanceof EnterMessage),
+      ((msg) -> msg.type is 'enter'),
       options,
       callback
     )
@@ -152,7 +152,7 @@ class Robot
   leave: (options, callback) ->
     @listeners.push new Listener(
       @,
-      ((msg) -> msg instanceof LeaveMessage),
+      ((msg) -> msg.type is 'leave'),
       options,
       callback
     )
@@ -167,7 +167,7 @@ class Robot
   topic: (options, callback) ->
     @listeners.push new Listener(
       @,
-      ((msg) -> msg instanceof TopicMessage),
+      ((msg) -> msg.type is 'topic'),
       options,
       callback
     )
@@ -212,7 +212,7 @@ class Robot
 
     @listeners.push new Listener(
       @,
-      ((msg) -> msg instanceof CatchAllMessage),
+      ((msg) -> msg.type is 'all'),
       options,
       ((msg) -> msg.message = msg.message.message; callback msg)
     )
@@ -233,7 +233,7 @@ class Robot
         @emit('error', error, new @Response(@, message, []))
 
         false
-    if message not instanceof CatchAllMessage and results.indexOf(true) is -1
+    if message.type isnt 'all' and results.indexOf(true) is -1
       @receive new CatchAllMessage(message)
 
   # Public: Loads a file in path.

--- a/test/listener_test.coffee
+++ b/test/listener_test.coffee
@@ -117,21 +117,20 @@ describe 'Listener', ->
           testMessage = new TextMessage(@user, 'test')
           testMessage.match = sinon.stub().returns(true)
           testRegex = /test/
- 
+
           testListener = new TextListener(@robot, testRegex, callback)
           result = testListener.matcher(testMessage)
- 
+
           expect(result).to.be.ok
           expect(testMessage.match).to.have.been.calledWith(testRegex)
- 
+
         it 'does not match EnterMessages', ->
           callback = sinon.spy()
           testMessage = new EnterMessage(@user)
-          testMessage.match = sinon.stub().returns(true)
           testRegex = /test/
- 
+
           testListener = new TextListener(@robot, testRegex, callback)
           result = testListener.matcher(testMessage)
- 
+
           expect(result).to.not.be.ok
-          expect(testMessage.match).to.not.have.been.called
+          expect(callback).to.not.have.been.called

--- a/test/listener_test.coffee
+++ b/test/listener_test.coffee
@@ -127,6 +127,7 @@ describe 'Listener', ->
         it 'does not match EnterMessages', ->
           callback = sinon.spy()
           testMessage = new EnterMessage(@user)
+          testMessage.match = sinon.stub().returns(true) # Invalid for a EnterMessage
           testRegex = /test/
 
           testListener = new TextListener(@robot, testRegex, callback)


### PR DESCRIPTION
Hubot is a plugin/adaptor framework that hosts them as node modules.
Those modules have their own dependencies versions. By depending on
types rather than interfaces, you run into the exact issue caused by
peerDependency explained [here](https://github.com/npm/npm/issues/5080)
