### PR TITLE
Method sendImage in Adapter API

### DIFF
--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -14,6 +14,16 @@ class Adapter extends EventEmitter
   # Returns nothing.
   send: (envelope, strings...) ->
 
+  # Public: Posts an image back to the chat source
+  #
+  # envelope - A Object with message, room and user details.
+  # url      - URL of the image resource
+  # strings  - One or more strings to be posted. The order of these strings
+  #            should be kept intact.
+  #
+  # Returns nothing.
+  sendImage: (envelope, url, strings...) ->
+
   # Public: Raw method for sending emote data back to the chat source.
   # Defaults as an alias for send
   #

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -21,6 +21,16 @@ class Response
   send: (strings...) ->
     @robot.adapter.send @envelope, strings...
 
+  # Public: Posts an image back to the chat source
+  #
+  # url     - URL of the image resource
+  # strings - One or more strings to be posted. The order of these strings
+  #           should be kept intact.
+  #
+  # Returns nothing.
+  sendImage: (url, strings...) ->
+    @robot.adapter.sendImage @envelope, url, strings...
+
   # Public: Posts an emote back to the chat source
   #
   # strings - One or more strings to be posted. The order of these strings


### PR DESCRIPTION
This PR is only to start a discussion, with the new Telegram bot API (https://github.com/lukefx/hubot-telegram) I've done an adapter to interact with the Telegram IM app, It's mainly used on mobile devices and it's possible to send and receive images.

At the moment it's not possible to do so with Hubot, you could send back and URL and usually the chat service will expand it to show the image.

Could we add the ability to do it natively? I've attached a proposal that works from my fork, but I would like to see what you think about it.

Example of scripts that reply with an image:

```
robot.respond /image me (.*)/i, (msg) ->
   msg.sendImage get_random_image(), caption
```
