### PR TITLE
makes script-documentation accessible via the robot.scriptDocumentati…

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -54,6 +54,7 @@ class Robot
     @logger     = new Log process.env.HUBOT_LOG_LEVEL or 'info'
     @pingIntervalId = null
     @globalHttpOptions = {}
+    @scriptDocumentation = []
 
     @parseVersion()
     if httpd
@@ -466,6 +467,8 @@ class Robot
         cleanedLine = line[2..line.length].replace(/^hubot/i, @name).trim()
         scriptDocumentation.commands.push cleanedLine
         @commands.push cleanedLine
+
+    @scriptDocumentation.push scriptDocumentation
 
   # Public: A helper send function which delegates to the adapter's send
   # function.


### PR DESCRIPTION
…on instance property

The parseHelp method already stores scriptDocumentation in a hash but does absolutely nothing with it. This mod pushes the stored documentation to an accessible @scriptDocumentation property so that other modules/scripts can make use of it (see https://www.npmjs.com/package/hubot-advanced-help, for example, which is a module I wrote that assumes this property exists). In the absence of this property, I'm going to have to resort to opening sibling scripts and parsing in the documentation even though the robot.coffee script already does that (it just does nothing with the data).

cc @imperialwicket @nealfax
