### PR TITLE
Add helper function to lookup Listeners

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -622,6 +622,35 @@ These scoped identifiers allow you to externally specify new behaviors like:
 - authorization policy: "allow everyone in the `annoyers` group to execute `annoyance.*` commands"
 - rate limiting: "only allow executing `annoyance.start` once every 30 minutes"
 
+## Fetching Listeners
+
+It is sometimes useful to retrieve a specific Listener (e.g. for unit testing). Listeners can be retrieved by their `id` attribute using `robot.listenerById`. Listener IDs are assumed to be unique, so only the first matching listener is returned if there are multiple matches.
+
+A unit testing example:
+
+The script:
+```coffeescript
+module.exports = (robot) ->
+  robot.respond /who is oncall?/, id: 'get-room-oncall', (response) ->
+    # it does stuff
+```
+
+The test:
+```coffeescript
+describe 'listener "get-room-oncall"', ->
+  it 'should match "who is oncall?"', (testDone) ->
+    listener = @robot.listenerById 'get-room-oncall'
+
+    # Stub out the real work; just testing the match
+    listener.callback = sinon.stub() # private API
+
+    testMessage = new TextMessage @user, "TestHubot: who is oncall?"
+
+    listener.call testMessage, (result) -> # private API
+      expect(result).to.be.ok
+      testDone()
+```
+
 # Listener Middleware
 
 Hubot supports inserting logic between the listener matching a message and the listener executing. This allows you to create extensions that apply to all scripts. Examples include centralized authorization policies, rate limiting, logging, and metrics. Middleware is implemented like other hubot scripts: instead of using the `hear` and `respond` methods, middleware is registered using `listenerMiddleware`.

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -221,6 +221,16 @@ class Robot
       ((msg) -> msg.message = msg.message.message; callback msg)
     )
 
+  # Public: Find the listener with matching ID. Behavior is undefined if
+  # multiple listeners have the same ID
+  #
+  # id - String that should exactly match listener.options.id
+  #
+  # Returns Listener instance
+  listenerById: (id) ->
+    results = @listeners.filter (listener) -> listener.options.id == id
+    results[0] or null
+
   # Public: Registers new middleware for execution after matching but before
   # Listener callbacks
   #

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -11,6 +11,7 @@ mockery = require 'mockery'
 Robot = require '../src/robot.coffee'
 { CatchAllMessage, EnterMessage, LeaveMessage, TextMessage, TopicMessage } = require '../src/message'
 Adapter = require '../src/adapter'
+{ Listener } = require '../src/listener'
 
 ScopedHttpClient = require 'scoped-http-client'
 
@@ -478,6 +479,25 @@ describe 'Robot', ->
         result = testListener.matcher(testMessage)
 
         expect(result).to.not.be.ok
+
+    describe '#listenerById', ->
+      beforeEach ->
+        # Mock the relevant fields
+        @testListener = options: id: 'test-listener'
+
+      it 'finds a listener with the given ID', ->
+        @robot.listeners = [ @testListener ]
+        expect(@robot.listenerById 'test-listener').to.be.equal(@testListener)
+
+      it 'returns null if no listener found', ->
+        @robot.listeners = [ @testListener ]
+        expect(@robot.listenerById 'fake-listener').to.be.null
+
+      it 'picks the first listener if multiple listeners found', ->
+        # Add an extra field to make debugging a failing test easier
+        @testListenerB = options: { id: 'test-listener', 'this-is': 'listener-b' }
+        @robot.listeners = [ @testListener, @testListenerB ]
+        expect(@robot.listenerById 'test-listener').to.be.equal(@testListener)
 
   describe 'Message Processing', ->
     it 'calls a matching listener', (done) ->


### PR DESCRIPTION
Solves the last need required for a couple issues:
https://github.com/github/hubot/issues/823#issuecomment-73999270
https://github.com/github/hubot/pull/686#issuecomment-74805659

Allows retrieving the named Listener object for unit testing or advanced scripting.
