### PR TITLE
Add a rawBody property to req object in custom HTTP listeners

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -421,6 +421,37 @@ curl -d 'payload=%7B%22secret%22%3A%22C-TECH+Astronomy%22%7D' http://127.0.0.1:8
 
 All endpoint URLs should start with the literal string `/hubot` (regardless of what your robot's name is). This consistency makes it easier to set up webhooks (copy-pasteable URL) and guarantees that URLs are valid (not all bot names are URL-safe).
 
+### Get raw body string
+
+Hubot maps the raw body to the req.rawBody property. This is important,
+if you need to do some hashing on the body of the request.
+
+Below is a simple example how to validate GitHub's push webhook request (HMAC).
+
+```coffeescript
+crypto = require 'crypto'
+
+module.exports = (robot) ->
+  robot.router.post '/hubot/github_hook/:room', (req, res) ->
+    room   = req.params.room
+    raw_payload = req.rawBody
+    github_secret = process.env.HUBOT_REPO_GITHUB_SECRET
+
+    # sha1 key must be a buffer
+    hmac = crypto.createHmac("sha1", new Buffer(github_secret))
+    hmac.update raw_payload
+    digest = hmac.digest 'hex'
+    # catch HMAC mismatch
+    if "sha1=#{digest}" isnt req.headers['x-hub-signature']
+      console.log "Auth error"
+      res.json 401, { send: true, error: true }
+      return
+
+    robot.messageRoom room, "#{req.body.pusher.name} pushed to #{req.body.repository.name}"
+
+    res.json { send: true }
+```
+
 ## Events
 
 Hubot can also respond to events which can be used to pass data between scripts. This is done by encapsulating node.js's [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter) with `robot.emit` and `robot.on`.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "async": ">=0.1.0 <1.0.0",
+    "body-parser": "^1.14.0",
     "chalk": "^1.0.0",
     "cline": "^0.8.2",
     "coffee-script": "1.6.3",
@@ -30,7 +31,8 @@
     "coffee-errors": "0.8.6",
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",
-    "sinon-chai": "^2.6.0"
+    "sinon-chai": "^2.6.0",
+    "supertest": "^1.1.0"
   },
   "engines": {
     "node": ">= 0.8.x",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure everything is development forever
 export NODE_ENV=development

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source script/bootstrap
 mocha --require coffee-errors --compilers coffee:coffee-script "$@"

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -400,8 +400,13 @@ class Robot
 
     express = require 'express'
     multipart = require 'connect-multiparty'
+    bodyParser = require 'body-parser'
 
     app = express()
+
+    app.use (req, res, next) =>
+      req.rawBody = ''
+      next()
 
     app.use (req, res, next) =>
       res.setHeader "X-Powered-By", "hubot/#{@name}"
@@ -410,8 +415,20 @@ class Robot
     app.use express.basicAuth user, pass if user and pass
     app.use express.query()
 
-    app.use express.json()
-    app.use express.urlencoded()
+    app.use bodyParser.json( verify: (req, res, buf, encoding) ->
+      req.rawBody = buf.toString()
+    )
+
+    app.use bodyParser.urlencoded( verify: (req, res, buf, encoding) ->
+      req.rawBody = buf.toString()
+    )
+
+    app.use bodyParser.text(
+      type: ['text/*', 'application/xml']
+      verify: (req, res, buf, encoding) ->
+        req.rawBody = buf.toString()
+    )
+
     # replacement for deprecated express.multipart/connect.multipart
     # limit to 100mb, as per the old behavior
     app.use multipart(maxFilesSize: 100 * 1024 * 1024)

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -415,12 +415,17 @@ class Robot
     app.use express.basicAuth user, pass if user and pass
     app.use express.query()
 
-    app.use bodyParser.json( verify: (req, res, buf, encoding) ->
-      req.rawBody = buf.toString()
+    app.use bodyParser.json(
+      verify: (req, res, buf, encoding) ->
+        req.rawBody = buf.toString()
     )
 
-    app.use bodyParser.urlencoded( verify: (req, res, buf, encoding) ->
-      req.rawBody = buf.toString()
+    # the extended false sets the parser to `querystring`
+    # https://github.com/expressjs/body-parser#bodyparserurlencodedoptions
+    app.use bodyParser.urlencoded(
+      verify: (req, res, buf, encoding) ->
+        req.rawBody = buf.toString()
+      extended: false
     )
 
     app.use bodyParser.text(


### PR DESCRIPTION
Hello,

I modified the express middleware that is used in custom HTTP listeners (routers) so that a hubot user can access the actual body of the request as a string object. 

The need for this is described in #923 . It's probably impossible to access the unprocessed body without monkey-patching hubot itself.

I need this for validating github webhooks that use HMAC.
I added an example in the documentation how to do this.

Accessing the body in express 3.x and testing middlewares is hard. After trying different approaches I decided to implement this solution: http://stackoverflow.com/a/26634372/807339 .

Mocha has a hard time detecting assert errors inside routers in the test cases. Therefore I had to rethrow them in the test context/namespace.
