### PR TITLE
Programmatically configured hubot

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -82,9 +82,7 @@ if Options.create
   process.exit 1
 
 else
-  adapterPath = Path.join __dirname, "..", "src", "adapters"
-
-  robot = Hubot.loadBot adapterPath, Options.adapter, Options.enableHttpd, Options.name, Options.alias
+  robot = Hubot.loadBot undefined, Options.adapter, Options.enableHttpd, Options.name, Options.alias
 
   if Options.version
     console.log robot.version

--- a/index.coffee
+++ b/index.coffee
@@ -5,6 +5,12 @@ Adapter                                                              = require '
 Response                                                             = require './src/response'
 {Listener,TextListener}                                              = require './src/listener'
 {Message,TextMessage,EnterMessage,LeaveMessage,TopicMessage,CatchAllMessage} = require './src/message'
+Shell                                                               = require './src/adapters/shell'
+Campfire                                                            = require './src/adapters/campfire'
+BuiltinAdapters = {
+  Shell
+  Campfire
+}
 
 module.exports = {
   User
@@ -20,6 +26,7 @@ module.exports = {
   LeaveMessage
   TopicMessage
   CatchAllMessage
+  BuiltinAdapters
 }
 
 module.exports.loadBot = (adapterPath, adapterName, enableHttpd, botName, botAlias) ->

--- a/src/adapters/campfire.coffee
+++ b/src/adapters/campfire.coffee
@@ -113,6 +113,7 @@ class Campfire extends Adapter
 
     self.emit "connected"
 
+module.exports = exports = Campfire
 exports.use = (robot) ->
   new Campfire robot
 

--- a/src/adapters/shell.coffee
+++ b/src/adapters/shell.coffee
@@ -97,5 +97,7 @@ class Shell extends Adapter
       else
         callback([])
 
+module.exports = exports = Shell
+
 exports.use = (robot) ->
   new Shell robot

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -62,7 +62,7 @@ class Robot
     else
       @setupNullRouter()
 
-    @loadAdapter adapter
+    @loadAdapter adapter if adapter?
 
     @adapterName   = adapter
     @errorHandlers = []
@@ -568,6 +568,9 @@ class Robot
   #
   # Returns nothing.
   run: ->
+    unless @adapter
+      throw new Error("no adapter present. did you forget to specify one or not call 'loadApdapter'?")
+
     @emit "running"
     @adapter.run()
 

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -448,7 +448,6 @@ class Robot
 
   # Load the adapter Hubot is going to use.
   #
-  # path    - A String of the path to adapter if local.
   # adapter - A String of the adapter name to use.
   #
   # Returns nothing.

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -34,13 +34,15 @@ class Robot
   # Robots receive messages from a chat source (Campfire, irc, etc), and
   # dispatch them to matching listeners.
   #
-  # adapterPath - A String of the path to local adapters.
+  # adapterPath -  A String of the path to built-in adapters (defaults to src/adapters)
   # adapter     - A String of the adapter name.
   # httpd       - A Boolean whether to enable the HTTP daemon.
   # name        - A String of the robot name, defaults to Hubot.
   #
   # Returns nothing.
   constructor: (adapterPath, adapter, httpd, name = 'Hubot', alias = false) ->
+    @adapterPath ?= Path.join __dirname, "adapters"
+
     @name       = name
     @events     = new EventEmitter
     @brain      = new Brain @
@@ -62,7 +64,7 @@ class Robot
     else
       @setupNullRouter()
 
-    @loadAdapter adapterPath, adapter
+    @loadAdapter adapter
 
     @adapterName   = adapter
     @errorHandlers = []
@@ -452,12 +454,12 @@ class Robot
   # adapter - A String of the adapter name to use.
   #
   # Returns nothing.
-  loadAdapter: (path, adapter) ->
+  loadAdapter: (adapter) ->
     @logger.debug "Loading adapter #{adapter}"
 
     try
       path = if adapter in HUBOT_DEFAULT_ADAPTERS
-        "#{path}/#{adapter}"
+        "#{@adapterPath}/#{adapter}"
       else
         "hubot-#{adapter}"
 

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -376,17 +376,33 @@ class Robot
   #
   # Returns nothing.
   loadExternalScripts: (packages) ->
-    @logger.debug "Loading external-scripts from npm packages"
     try
       if packages instanceof Array
-        for pkg in packages
-          require(pkg)(@)
+        @loadScriptPackage(pkg) for pkg in packages
       else
-        for pkg, scripts of packages
-          require(pkg)(@, scripts)
+        @loadScriptPackage(pkg, scripts) for pkg, scripts of packages
+
+  # Public: load a script from an npm module
+  #
+  # pkg - A string of the package to load, or a script that has been required, but hasn't been loaded yet
+  # scripts - An Array of scripts to load from the package (optional)
+  #
+  # Examples:
+  #   robot.loadScriptPackage require('hubot-help')
+  #   robot.loadScriptPackage 'hubot-help'
+  #
+  # Note:
+  #   Specifying package as string may fail depending on your NODE_PATH settings.
+  #   This can be fixed by requiring the package, and passing that to this function.
+  #
+  # Returns nothing
+  loadScriptPackage: (pkg, scripts) ->
+    try
+      pkg = require(pkg) unless typeof(pkg) is 'function'
     catch err
       @logger.error "Error loading scripts from npm package - #{err.stack}"
       process.exit(1)
+    pkg(@, scripts)
 
   # Setup the Express server's defaults.
   #

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -40,13 +40,11 @@ class Robot
   # name        - A String of the robot name, defaults to Hubot.
   #
   # Returns nothing.
-  constructor: (adapterPath, adapter, httpd, name = 'Hubot', alias = false) ->
+  constructor: (adapterPath, adapter, httpd, @name = 'Hubot', @alias = false) ->
     @adapterPath ?= Path.join __dirname, "adapters"
 
-    @name       = name
     @events     = new EventEmitter
     @brain      = new Brain @
-    @alias      = alias
     @adapter    = null
     @Response   = Response
     @commands   = []


### PR DESCRIPTION
Once I got https://github.com/github/hubot/pull/1109 working in a single file, started to pick at some of the API that didn't feel great:
- `Robot` constructor has positional arguments, which means they don't make much sense when you are looking at `new Hubot.Robot(null, 'shell', false, 'Hubot', '/')`
- `adapter` is loaded at Robot construction time. the `loadAdapter` is just a wrapper around loading a builtin adapter vs a npm module
- `loadAdapter` expects an adapter's exports to define a `use` method, and in reality, that seems to only ever return a new instance of the adapter that takes a robot. Why not construct this directly?
- loading an npm script package looks weird. we require it only to call it with the robot. this is the problem of the script API exporting a function though

What this does so far:
- constructor can now be called without any args
- update builtin adapter to export the adapter class, and make those accessible from top-level `require 'hubot'`
- don't load adapter if one wasn't given (in the case of constructor without any arg)
- add `loadScriptPackage` helper, which reads a little better but doesn't do much

Some open-ended questions / problems:
- making sure to preserve backwards compatibility
- handling environment specific configuration. should you hard-code name, alias, etc? environment variable? assign from an environment variable? should there be like a `config/environments.coffee` like Rails has, and `config/environments/development.coffee` for dev, `config/environments/production.coffee` for production, etc?
- does this make it easier to test? harder?
- does `bin/hubot` need to exist? does it need to support a programatic launch, or do you only use progmatic launch OR bin/hubot?

cc https://github.com/github/hubot/issues/858
