### PR TITLE
Rename Hubot at runtime using respondPattern

### DIFF
--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -104,7 +104,21 @@ class TextListener extends Listener
         message.match @regex
     super @robot, @matcher, @options, @callback
 
+class RespondListener extends TextListener
+  # RespondListeners receive every message from the chat source and decide if they
+  # want to act on it.
+  #
+  # robot    - A Robot instance.
+  # regex    - A RegExp for the message part that follows the robot's name/alias.
+  # options  - An Object of additional parameters keyed on extension name
+  #            (optional).
+  # callback - A Function that is triggered if the incoming message matches.
+  constructor: (@robot, @originalRegex, @options, @callback) ->
+    @regex = @robot.respondPattern(@originalRegex)
+    super @robot, @regex, @options, @callback
+
 module.exports = {
   Listener
   TextListener
+  RespondListener
 }

--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -8,7 +8,7 @@ async          = require 'async'
 User = require './user'
 Brain = require './brain'
 Response = require './response'
-{Listener,TextListener} = require './listener'
+{Listener,TextListener,RespondListener} = require './listener'
 {EnterMessage,LeaveMessage,TopicMessage,CatchAllMessage} = require './message'
 Middleware = require './middleware'
 
@@ -112,7 +112,7 @@ class Robot
   #
   # Returns nothing.
   respond: (regex, options, callback) ->
-    @hear(@respondPattern(regex), options, callback)
+    @listeners.push new RespondListener(@, regex, options, callback)
 
   # Public: Build a regular expression that matches messages addressed
   # directly to the robot
@@ -147,6 +147,24 @@ class Robot
       )
 
     newRegex
+
+  # Public: Updates the robot name and its listeners accordingly.
+  #
+  # newName - A String of the new robot name.
+  #
+  # Returns nothing.
+  changeName: (newName) ->
+    # Updates the name.
+    @name = newName
+
+    # Reconstructs respond listeners:
+    listeners = []
+    for listener in @listeners
+      if listener instanceof RespondListener
+        listeners.push new RespondListener(@, listener.originalRegex, listener.options, listener.callback)
+      else
+        listeners.push listener
+    @listeners = listeners
 
   # Public: Adds a Listener that triggers when anyone enters the room.
   #

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -82,6 +82,20 @@ describe 'Robot', ->
         httpClient = @robot.http('http://localhost', agent: agentB)
         expect(httpClient.options.agent).to.equal(agentB)
 
+    describe '#changeName', ->
+      it 'updates the name', ->
+        expect(@robot.name).to.equal('TestHubot')
+        @robot.changeName 'Testbot'
+        expect(@robot.name).to.equal('Testbot')
+
+      it 'updates listeners with the new name', ->
+        @robot.respond /.*/, ->
+        regex = @robot.listeners[0].regex.toString()
+        expect(regex).to.equal('/^\\s*[@]?(?:TestHubot[:,]?|Hubot[:,]?)\\s*(?:.*)/')
+        @robot.changeName 'Testbot'
+        regex = @robot.listeners[0].regex.toString()
+        expect(regex).to.equal('/^\\s*[@]?(?:Testbot[:,]?|Hubot[:,]?)\\s*(?:.*)/')
+
     describe '#respondPattern', ->
       it 'matches messages starting with robot\'s name', ->
         testMessage = @robot.name + 'message123'
@@ -155,10 +169,10 @@ describe 'Robot', ->
         expect(@robot.listeners).to.have.length(1)
 
     describe '#respond', ->
-      it 'registers a new listener using hear', ->
-        sinon.spy @robot, 'hear'
-        @robot.respond /.*/, ->
-        expect(@robot.hear).to.have.been.called
+      it 'registers a new listener directly', ->
+        expect(@robot.listeners).to.have.length(0)
+        @robot.hear /.*/, ->
+        expect(@robot.listeners).to.have.length(1)
 
     describe '#enter', ->
       it 'registers a new listener using listen', ->
@@ -413,6 +427,19 @@ describe 'Robot', ->
         result = testListener.matcher(testMessage)
 
         expect(result).to.not.be.ok
+
+    describe '#changeName', ->
+      it 'still matches TextMessages addressed to the robot', ->
+        callback = sinon.spy()
+        testMessage = new TextMessage(@user, 'Testbot Message123')
+        testRegex = /message123$/i
+
+        @robot.respond(testRegex, callback)
+        @robot.changeName 'Testbot'
+
+        testListener = @robot.listeners[0]
+        result = testListener.matcher(testMessage)
+        expect(result).to.be.ok
 
     describe '#enter', ->
       it 'matches EnterMessages', ->


### PR DESCRIPTION
Second implementation for #1093 (first was #1104); this pull request adds a `changeName` method to Robot to change its name at runtime. It updates the name and the `respond` listeners.
It reconstructs listeners using `respondPattern`. The original regex are saved in the `RespondListener` objects.

Should `respond` also notify the `@adapter` of the name change? (I suppose the server, too, needs to change the bot's name.)
<br>

My use case for this has to do with IRC. Under certain conditions, Hubot can be assigned an alternate nickname when connecting to the server. I'd like to be able to reassign the primary name when it becomes possible, without restarting Hubot.
I imagine this could prove useful in other situations.
<br>

From the first pull request (#1104):

> If people change the name, do you think they'd want to change the alias too?

I can't think of a case where the alias would need to be changed regularly, but maybe that should be possible, at least to be consistent.

> I'd also wonder if there's any caveats to supporting this. Imagine I'm talking to hubot in one room, and someone changes the name somewhere else. I'd expect hubot to still be respond, but it'd start silently ignoring me until I found the new name.

Maybe Hubot could announce his new name?
<br>

Note: I haven't updated `scripting.md` yet.
