### PR TITLE
Add support for Babel 6 export default

### DIFF
--- a/src/robot.coffee
+++ b/src/robot.coffee
@@ -354,6 +354,10 @@ class Robot
       try
         script = require(full)
 
+        # Support Babel 6's `export default function`
+        if typeof script.default is 'function'
+          script = script.default
+
         if typeof script is 'function'
           script @
           @parseHelp Path.join(path, file)

--- a/test/robot_test.coffee
+++ b/test/robot_test.coffee
@@ -341,6 +341,22 @@ describe 'Robot', ->
           @robot.loadFile('./scripts', 'test-script.coffee')
           expect(@robot.parseHelp).to.have.been.calledWith('scripts/test-script.coffee')
 
+      describe "script generated using Babel 6's export default", ->
+        beforeEach ->
+          module = require 'module'
+
+          @script = default: sinon.spy((robot) ->)
+          @sandbox.stub(module, '_load').returns(@script)
+          @sandbox.stub @robot, 'parseHelp'
+
+        it 'should call the script with the Robot', ->
+          @robot.loadFile('./scripts', 'test-script.coffee')
+          expect(@script.default).to.have.been.calledWith(@robot)
+
+        it 'should parse the script documentation', ->
+          @robot.loadFile('./scripts', 'test-script.coffee')
+          expect(@robot.parseHelp).to.have.been.calledWith('scripts/test-script.coffee')
+
       describe 'non-Function script', ->
         beforeEach ->
           module = require 'module'


### PR DESCRIPTION
Hey, I'm the author of [babel-hubot](https://github.com/kossnocorp/babel-hubot), minimalistic Hubot wrapper that allows to use Babel to compile scripts written in JS.

Prior to Babel 6, integration was super simple:

``` diff
--- a/bin/hubot
+++ b/bin/hubot
@@ -3,4 +3,4 @@
 npm install
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"

-exec node_modules/.bin/hubot "$@"
+exec node_modules/.bin/babel-hubot "$@"
```

Unfortunately in 6th version, Babel [changed the way how `export default` is handled](http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default), so now:

``` js
export default function() {}
```

... is not equal to:

``` js
module.exports = function() {}
```

... but to:

``` js
module.exports = {default: function() {}}
```

To make it work properly I had to change Hubot itself and check if `script.default` is a function and then use it instead of `script`.
