### PR TITLE
add node-env-file to hubot to parse .env files

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -7,6 +7,8 @@ Hubot    = require '..'
 Fs       = require 'fs'
 OptParse = require 'optparse'
 Path     = require 'path'
+env      = require 'node-env-file'
+env('.env', {verbose: false, raise: false})
 
 Switches = [
   [ "-a", "--adapter ADAPTER", "The Adapter to use" ],

--- a/bin/hubot
+++ b/bin/hubot
@@ -7,8 +7,7 @@ Hubot    = require '..'
 Fs       = require 'fs'
 OptParse = require 'optparse'
 Path     = require 'path'
-env      = require 'node-env-file'
-env('.env', {verbose: false, raise: false})
+env      = require('dotenv').config({silent: true}); 
 
 Switches = [
   [ "-a", "--adapter ADAPTER", "The Adapter to use" ],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "connect-multiparty": "^1.2.5",
     "express": "^3.21.2",
     "log": "1.4.0",
+    "node-env-file": "^0.1.8",
     "optparse": "1.0.4",
     "scoped-http-client": "0.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "cline": "^0.8.2",
     "coffee-script": "1.6.3",
     "connect-multiparty": "^1.2.5",
+    "dotenv": "^2.0.0",
     "express": "^3.21.2",
     "log": "1.4.0",
-    "node-env-file": "^0.1.8",
     "optparse": "1.0.4",
     "scoped-http-client": "0.11.0"
   },


### PR DESCRIPTION
Adding node-env-file to bin/hubot so it can read standard node .env files 
Reference:  issue #1153 

If someone can suggest where this should be documented I will add documentation changes to pull request.
