### PR TITLE
Handle promise returning listener callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "coffee-script": "1.6.3",
     "connect-multiparty": "^1.2.5",
     "express": "^3.21.2",
+    "is-promise": "^2.1.0",
     "log": "1.4.0",
     "optparse": "1.0.4",
     "scoped-http-client": "0.11.0"


### PR DESCRIPTION
This is just an early PR to see what kind of appetite there is for this change. We've got some Hubot scripts which make use of `async`/`await` [via Babel](https://babeljs.io/docs/plugins/transform-async-to-generator/). It keeps things fairly readable while we do stuff like make API calls.

Here's a simplified example (please excuse the JS and any CS weirdness... I rarely write CS!):

``` js
// test.js

module.exports = function(robot){
  robot.respond(/test/i, async function(msg){
    msg.send('starting');
    await delay(1000);
    msg.send('ending');
  });
};

function delay(ms) {
  return new Promise(function(resolve){
    setTimeout(resolve, ms);
  });
}
```

And an example test script that uses [hubot-test-helper](https://github.com/mtsmfm/hubot-test-helper):

``` js
// test.spec.js

import Helper from 'hubot-test-helper';

const helper = new Helper('./test.js');

describe('test script', function(){
  it('should complete', async function(){
    const room = helper.createRoom();
    await room.user.say('seinfeld', '@hubot test');
    expect(room.messages).to.deep.eq([
      ['seinfeld', '@hubot test'],
      ['hubot', 'starting'],
      ['hubot', 'ending']
    ]);
    room.destroy();
  });
});
```

Currently the above test fails, since the `ending` message is not received before the test finishes. [On closer inspection](https://github.com/github/hubot/blob/master/src/listener.coffee#L62), this appears to be due to the `listener` not handling callbacks that return promises.

One way to fix things is to update the `listener` as per this PR, but is this worth progressing further?
