### PR TITLE
Add Istanbul for coverage and coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .hubot_history
 .node-version
+.nyc_output/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .hubot_history
 .node-version
 .nyc_output/
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .node-version
 .nyc_output/
 npm-debug.log
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ node_js:
 notifications:
   email: false
 sudo: false
+after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/espy/hubot/badge.svg?branch=master)](https://coveralls.io/github/espy/hubot?branch=master)
+
 # Hubot
 
 Hubot is a framework to build chat bots, modeled after GitHub's Campfire bot of the same name, hubot.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://coveralls.io/repos/github/espy/hubot/badge.svg?branch=master)](https://coveralls.io/github/espy/hubot?branch=master)
+[![Build Status](https://travis-ci.org/espy/hubot.svg?branch=master)](https://travis-ci.org/espy/hubot) [![Coverage Status](https://coveralls.io/repos/github/espy/hubot/badge.svg?branch=master)](https://coveralls.io/github/espy/hubot?branch=master)
 
 # Hubot
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "chai": "~2.1.0",
+    "coveralls": "^2.13.1",
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",
     "nyc": "^11.0.2",
@@ -45,7 +46,8 @@
   "scripts": {
     "start": "bin/hubot",
     "pretest": "standard",
-    "test": "nyc mocha",
+    "test": "nyc --reporter=html --reporter=text mocha",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test:smoke": "node src/**/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
     "scoped-http-client": "0.11.0"
   },
   "devDependencies": {
+    "chai": "~2.1.0",
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",
-    "sinon-chai": "^2.8.0",
+    "nyc": "^11.0.2",
     "sinon": "~1.17.0",
-    "standard": "^10.0.2",
-    "chai": "~2.1.0"
+    "sinon-chai": "^2.8.0",
+    "standard": "^10.0.2"
   },
   "engines": {
     "node": ">= 0.8.x",
@@ -44,7 +45,7 @@
   "scripts": {
     "start": "bin/hubot",
     "pretest": "standard",
-    "test": "mocha",
+    "test": "nyc mocha",
     "test:smoke": "node src/**/*.js"
   }
 }


### PR DESCRIPTION
Hello 👋 

This PR adds Istanbul to measure test coverage and add settings to track coverage over time with https://coveralls.io 

We (@gr2m and me) think this is crucial for adding `semantic-release` and Greenkeeper to Hubot, both of which depend on reliable tests, and ideally 100% coverage. `semantic-release` uses tests to determine whether a commit introduces breaking changes, and Greenkeeper uses tests to determine whether a dependency update breaks Hubot. We’d like to automate away as much of the release process as possible (to make it more convenient, so we can release more often, and to avoid [sentimental versioning](http://sentimentalversioning.org/), and we’d like to use Greenkeeper to be sure that users don’t get frustrated with Hubot because some dependency broke it without us noticing. 

- `npm test` now displays coverage information at the end of each test run
- The readme now shows build status and coverage info badges
- Hubot has a status page on coveralls.io (check this page from `hoodiehq/hoodie` https://coveralls.io/github/hoodiehq/hoodie to see what this looks like)

Coveralls.io requires additional configuration:

- [x] An admin/owner of `github/hubot` must sign in to https://coveralls.io with their GitHub account
- [x] On https://coveralls.io/repos/new , enable `github/hubot`
- [x] On https://coveralls.io/github/{username}/hubot/settings, disable `leave comments`
- [x] On the same page, set `coverage decrease threshold for failure` to `0` and save changes
- [x] Check `coveralls/coveralls` in `Require status checks to pass before merging` on https://github.com/github/hubot/settings/branches/master

Coveralls now runs when Travis runs, and the build should fail when coverage falls below the previous test run’s level. 