### PR TITLE
parse help from script

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -516,8 +516,10 @@ class Robot {
   // Returns nothing.
   parseHelp (path) {
     const scriptDocumentation = {}
-    const body = fs.readFileSync(path, 'utf-8')
-    const lines = body.split('\n')
+    const body = fs.readFileSync(require.resolve(path), 'utf-8')
+
+    const useStrictHeaderRegex = /^["']use strict['"];?\s+/
+    const lines = body.replace(useStrictHeaderRegex, '').split('\n')
       .reduce(toHeaderCommentBlock, {lines: [], isHeader: true}).lines
       .filter(Boolean) // remove empty lines
     let currentSection = null


### PR DESCRIPTION
I run into these problems while converting `hubot-help` from CoffeeScript to JavaScript. This is currently not covered by `hubot` tests. Having an end-to-end test that runs on CI would have caught that. I’ll look into it, but would like to merge this now if possible, as the change is minor