### PR TITLE
Document using a custom listener to check for message text

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -297,6 +297,9 @@ The match function must return a truthy value if the listener callback should be
 module.exports = (robot) ->
   robot.listen(
     (message) -> # Match function
+      # only match messages with text (ie ignore enter and other events)
+      return unless message.text
+
       # Occassionally respond to things that Steve says
       message.user.name is "Steve" and Math.random() > 0.8
     (response) -> # Standard listener callback


### PR DESCRIPTION
Without this, any message is responded to, including someone entering or
leaving. Most common case is responding to text, so make sure to check
for that in the docs, and explain why.

Fixes https://github.com/hubotio/hubot/issues/1055