### PR TITLE
Updating docs for deploying to Bluemix

### DIFF
--- a/docs/deploying/bluemix.md
+++ b/docs/deploying/bluemix.md
@@ -11,34 +11,39 @@ to deploy so you can use it beyond just your local machine.
 [Cloud Foundry](https://www.cloudfoundry.org/), so we'll be using the `cf cli`
 throughout these examples.
 
-Unlike Heroku, the free tier on Bluemix supports 24/7 uptime, so you don't need
-to go through the hassle of setting up something like
-[hubot-heroku-keepalive](https://github.com/hubot-scripts/hubot-heroku-keepalive).
+Hubot was originally very closely coupled to Heroku, so there are a couple of
+things to clean up first that we don't need or that might get in the way on
+another platform:
+* remove `Procfile` as we'll create the `manifest.yml` that Bluemix needs in a
+ moment
+* remove the `hubot-heroku-keepalive` line from `external_scripts.json` and also
+ remove the related npm module (it causes errors on other platforms):
 
-You will need to install the
-[Cloud Foundry CLI](https://github.com/cloudfoundry/cli/releases), and create a
-[Bluemix Account](http://bluemix.net).
+  npm uninstall --save hubot-heroku-keepalive
 
-First we need to define a `manifest.yml` file in the root directory (and delete
-the generated `procfile`). The contents of the manifest at the bare minimum
-should look like:
+In preparation for working with Bluemix, install the [Cloud Foundry
+CLI](https://github.com/cloudfoundry/cli/releases), and create a [Bluemix
+Account](http://bluemix.net).
+
+First we need to define a `manifest.yml` file in the root directory. The
+contents of the manifest at the bare minimum should look like:
 
 ```yml
 applications:
-- buildpack: https://github.com/jthomas/nodejs-v4-buildpack.git
+- name: myVeryOwnHubot
   command: ./bin/hubot --adapter slack
-  path: .
   instances: 1
-  memory: 256M
+  memory: 512M
 ```
 
-In this example, we're using the slack adapter (as shown by the start command).
-Of course, the start command can be whatever you need to start your specific
-hubot. You can optionally set a `host`, and `name`, and much more, or you can
-set those up through the Bluemix GUI in the dashboard. For thorough
-documentation on what the `manifest.yml` file does and how it used and how to
-configure your own, see
-[these docs](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html).
+In this example, we're using the slack adapter, if you choose slack as your
+adapter when creating a hubot this will work, otherwise add the `hubot-slack`
+module to your `package.json`.  **Change the name of your hubot in the
+`manifest.yml` file** because otherwise your application will clash with someone
+else's who already deployed an app called this!  There are many more useful
+things you can change about your hubot using the manifest file, so check out
+[these docs](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html)
+for more information.
 
 You then need to connect your hubot project to Bluemix:
 
@@ -48,60 +53,38 @@ $ cf api https://api.ng.bluemix.net
 $ cf login
 ```
 
-This will prompt you with your login credentials. Then to deploy your hubot, all
-you need to do is:
+Note that the `cf api` command changes per Bluemix region so to deploy somewhere
+other than "US South", replace this api as appropriate.  The `cf login` command
+will prompt you with your login credentials.
+
+Next, we need to set up our environment variables, but we need to create the app
+first.  It won't work properly without the environment variables it needs, so
+we'll first of all use the `--no-start` flag to deploy but not attempt to start
+it.
 
 ```sh
-$ cf push NAME_OF_YOUR_HUBOT_APP
+$ cf push NAME_OF_YOUR_HUBOT_APP --no-start
 ```
 
-Note: if you do not specify a `name` and `host` in your manifest, you will have
-needed to create a `Node.js` Cloudfoundry app in the Bluemix dashboard. You then
-use the name that of that app in your `cf push` command. For very thorough
-documentation on deploying a Node.js app to Bluemix, please
-[read here](https://www.ng.bluemix.net/docs/starters/nodejs/index.html), for
-very thorough documentation of the command line interface, please
-[read here](https://www.ng.bluemix.net/docs/cli/reference/cfcommands/index.html).
-
-Finally you will need to add the environment variables to the website to make
-sure it runs properly. You can either do it through the GUI (under your app's
-dashboard) or you can use the command line, as follows (example is showing slack
-as an adapter):
+Now the app exists, we can set its environment variables.  To access slack,
+you'll need a slack token from the "Apps and Integrations" page; it's visible
+when you go to create a slackbot.  Copy that token and set it as an environment
+variable called `HUBOT_SLACK_TOKEN`, like this:
 
 ```sh
 $ cf set-env NAME_OF_YOUR_HUBOT_APP HUBOT_SLACK_TOKEN TOKEN_VALUE
 ```
 
-### Usage With Git
+If you have other environment variables to set, such as configuring the
+`REDIS_URL` for `hubot-redis-brain`, this is a good time to do that.
 
-It is not mandatory to use Bluemix with git, but Bluemix supports delivery
-pipelines that can be tied to Github, Github Enterprise, or a private JazzHub
-repo.
-
-Inside your new hubot directory, make sure you've created a git repository,
-and that your work is committed:
+Finally, we're ready to go!  Deploy "for real" this time:
 
 ```sh
-$ git init
-$ git add .
-$ git commit -m "Initial commit"
+$ cf push NAME_OF_YOUR_HUBOT_APP
 ```
 
-Then [create a GitHub repository](https://help.github.com/articles/create-a-repo/)
-for your hubot. This is where Bluemix will pull your code from instead of
-needing to deploy directly from your dev machine to Bluemix.
-
-```sh
-$ git remote add origin _your GitHub repo_
-$ git push -u origin master
-```
-
-Once you have your GitHub repo, navigate to your project dashboard, and click
-"add git" (in the upper right hand corner). This will guide you through the
-process of using either your Github account, or setting up a JazzHub account.
-You can then add any permutations of test/build/deploy stages into your
-pipeline. For thorough documentation on that, see
-[here](https://www.ng.bluemix.net/docs/#services/DeliveryPipeline/index.html#getstartwithCD).
+You should see your bot connect to slack!
 
 ### Further Reading
 
@@ -110,3 +93,19 @@ pipeline. For thorough documentation on that, see
   - [Setting up your manifest](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html)
   - [Understanding the CF CLI](https://www.ng.bluemix.net/docs/cli/reference/cfcommands/index.html)
   - [Setting up a Build Pipleline in Bluemix](https://www.ng.bluemix.net/docs/#services/DeliveryPipeline/index.html#getstartwithCD)
+
+### Troubleshooting
+
+**Bot doesn't connect**
+
+Check your logs for more information using the command `cf logs YOUR_APP_NAME
+--recent`.  If you have NodeJS installed locally, you can also try running the
+bot on your local machine to inspect any output: simply do `bin/hubot` from the
+top level of the project.
+
+**Bot crashes repeatedly**
+
+It is sometimes necessary to to assign more memory to your hubot, depending
+which plugins you are using (if your app crashes with error 137, try increasing
+the memory limit).
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,8 +119,10 @@ You can deploy hubot to Heroku, which is the officially supported method.
 Additionally you are able to deploy hubot to a UNIX-like system or Windows.
 Please note the support for deploying to Windows isn't officially supported.
 
+* [Deploying Hubot onto Azure](./deploying/azure.md)
+* [Deploying Hubot onto Bluemix](./deploying/bluemix.md)
 * [Deploying Hubot onto Heroku](./deploying/heroku.md)
-* [Deploying Hubot onto UNIX](./deploying/unix.md)
+* [Deploying Hubot onto Unix](./deploying/unix.md)
 * [Deploying Hubot onto Windows](./deploying/windows.md)
 
 ## Patterns


### PR DESCRIPTION
I tried to use the deploy instructions for Bluemix but they're a little outdated so I've updated them now my own hubot is running happily there.  This also adds the missing Bluemix and Azure deployment instructions to the list of deployment info on the index page.