### PR TITLE
Robot loadFile and parseHelp tests and method improvements

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -555,7 +555,7 @@ class Robot {
     }
 
     if (currentSection === null) {
-      this.logger.info(`${path} is using deprecated documentation syntax`)
+      this.logger.info(`${path} is missing documentation or using an unrecognised documentation syntax`)
       scriptDocumentation.commands = []
       for (let i = 0, line, cleanedLine; i < lines.length; i++) {
         line = lines[i]

--- a/src/robot.js
+++ b/src/robot.js
@@ -731,11 +731,11 @@ function toHeaderCommentBlock (block, currentLine) {
 }
 
 function isCommentLine (line) {
-  return /^(#|\/\/)/.test(line)
+  return /^\s*(#|\/\/|\/?\*)/.test(line)
 }
 
 function removeCommentPrefix (line) {
-  return line.replace(/^[#/]+\s*/, '')
+  return line.replace(/^\s*[#/*]+\s*/, '')
 }
 
 function extend (obj/* , ...sources */) {

--- a/src/robot.js
+++ b/src/robot.js
@@ -349,9 +349,11 @@ class Robot {
   loadFile (filepath, filename) {
     const ext = path.extname(filename)
     const full = path.join(filepath, path.basename(filename, ext))
+    const accepted = ['.js', '.coffee']
 
     // see https://github.com/hubotio/hubot/issues/1355
-    if (!require.extensions[ext]) { // eslint-disable-line
+    if (accepted.indexOf(ext) === -1) {
+      this.logger.warning(`${filename} uses unsupported extension, only ${accepted.join(', ')} are accepted`)
       return
     }
 

--- a/src/robot.js
+++ b/src/robot.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('events').EventEmitter
 const fs = require('fs')
 const path = require('path')
+require('coffee-script') // registers extension for legacy script loading
 
 const async = require('async')
 const Log = require('log')

--- a/test/robot_test.js
+++ b/test/robot_test.js
@@ -384,7 +384,7 @@ describe('Robot', function () {
         expect(module._load).to.have.been.calledWith('scripts/test-script')
       })
 
-      describe('proper script', function () {
+      describe('proper script (js)', function () {
         let script
 
         beforeEach(function () {
@@ -392,6 +392,41 @@ describe('Robot', function () {
             path: path.resolve('./test/scripts'),
             file: 'test-script.js',
             full: path.resolve('./test/scripts/test-script.js')
+          }
+          script.required = require(script.full)
+          this.sandbox.stub(require('module'), '_load').returns(script.required)
+          sinon.spy(this.robot, 'parseHelp')
+        })
+        afterEach(function () {
+          this.robot.parseHelp.restore()
+        })
+
+        it('should call the script with the Robot', function () {
+          this.robot.loadFile(script.path, script.file)
+          expect(script.required).to.have.been.calledWith(this.robot)
+        })
+
+        it('should parse the script documentation', function () {
+          this.robot.loadFile(script.path, script.file)
+          expect(this.robot.parseHelp).to.have.been.calledWith(script.full)
+        })
+
+        it('passes the commands in script comment documentation', function () {
+          this.robot.loadFile(script.path, script.file)
+          expect(this.robot.commands).to.eql([
+            'hubot <ping> - replies @user pong'
+          ])
+        })
+      })
+
+      describe('proper script (coffee)', function () {
+        let script
+
+        beforeEach(function () {
+          script = {
+            path: path.resolve('./test/scripts'),
+            file: 'test-script.coffee',
+            full: path.resolve('./test/scripts/test-script.coffee')
           }
           script.required = require(script.full)
           this.sandbox.stub(require('module'), '_load').returns(script.required)

--- a/test/robot_test.js
+++ b/test/robot_test.js
@@ -476,12 +476,17 @@ describe('Robot', function () {
 
           this.script = sinon.spy(function (robot) {})
           this.sandbox.stub(module, '_load').returns(this.script)
-          this.sandbox.stub(this.robot, 'parseHelp')
+          this.sandbox.stub(this.robot.logger, 'warning')
         })
 
         it('should not be loaded by the Robot', function () {
           this.robot.loadFile('./scripts', 'unsupported.yml')
           expect(this.script).to.not.have.been.calledWith(this.robot)
+        })
+
+        it('logs a warning', function () {
+          this.robot.loadFile('./scripts', 'unsupported.yml')
+          expect(this.robot.logger.warning).to.have.been.called
         })
       })
     })

--- a/test/scripts/test-script.coffee
+++ b/test/scripts/test-script.coffee
@@ -1,0 +1,10 @@
+# Description:
+# Says pong when you say ping
+#
+# Commands:
+# hubot <ping> - replies @user pong
+#
+sinon = require 'sinon'
+module.exports = sinon.spy (robot) ->
+  robot.respond /ping/i, (res) ->
+    res.reply 'pong'

--- a/test/scripts/test-script.js
+++ b/test/scripts/test-script.js
@@ -1,0 +1,16 @@
+/**
+ * Description:
+ * Says pong when you say ping
+ *
+ * Commands:
+ * hubot <ping> - replies @user pong
+ *
+ * Notes:
+ * Sinon spies on exported function for unit tests
+ */
+const sinon = require('sinon')
+module.exports = sinon.spy(function (robot) {
+  robot.respond(/ping/i, function (res) {
+    res.reply('pong')
+  })
+})


### PR DESCRIPTION
This PR will address several issues in hubot v3 script loading.

1. Can't parse documentation in js files #1375 
2. Can't load coffee script files (to support legacy scripts) #1376
3. Warnings are misleading and some errors silent #1377
3. Can't process es6 exports #1374 

Currently just adds failing tests for #1375 