### PR TITLE
Fix robot helpers delegation to adapter and events

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -579,7 +579,7 @@ class Robot {
   send (envelope/* , ...strings */) {
     const strings = [].slice.call(arguments, 1)
 
-    this.adapter.send.apply(this, [envelope].concat(strings))
+    this.adapter.send.apply(this.adapter, [envelope].concat(strings))
   }
 
   // Public: A helper reply function which delegates to the adapter's reply
@@ -592,7 +592,7 @@ class Robot {
   reply (envelope/* , ...strings */) {
     const strings = [].slice.call(arguments, 1)
 
-    this.adapter.reply.apply(this, [envelope].concat(strings))
+    this.adapter.reply.apply(this.adapter, [envelope].concat(strings))
   }
 
   // Public: A helper send function to message a room that the robot is in.
@@ -605,7 +605,7 @@ class Robot {
     const strings = [].slice.call(arguments, 1)
     const envelope = { room }
 
-    this.adapter.send.apply(this, [envelope].concat(strings))
+    this.adapter.send.apply(this.adapter, [envelope].concat(strings))
   }
 
   // Public: A wrapper around the EventEmitter API to make usage
@@ -619,7 +619,7 @@ class Robot {
   on (event/* , ...args */) {
     const args = [].slice.call(arguments, 1)
 
-    this.events.on.apply(this, [event].concat(args))
+    this.events.on.apply(this.events, [event].concat(args))
   }
 
   // Public: A wrapper around the EventEmitter API to make usage
@@ -632,7 +632,7 @@ class Robot {
   emit (event/* , ...args */) {
     const args = [].slice.call(arguments, 1)
 
-    this.events.emit.apply(this, [event].concat(args))
+    this.events.emit.apply(this.events, [event].concat(args))
   }
 
   // Public: Kick off the event loop for the adapter

--- a/test/robot_test.js
+++ b/test/robot_test.js
@@ -434,6 +434,61 @@ describe('Robot', function () {
         })
       })
     })
+
+    describe('#send', function () {
+      beforeEach(function () {
+        sinon.spy(this.robot.adapter, 'send')
+      })
+
+      it('delegates to adapter "send" with proper context', function () {
+        this.robot.send({}, 'test message')
+        expect(this.robot.adapter.send).to.have.been.calledOn(this.robot.adapter)
+      })
+    })
+
+    describe('#reply', function () {
+      beforeEach(function () {
+        sinon.spy(this.robot.adapter, 'reply')
+      })
+
+      it('delegates to adapter "reply" with proper context', function () {
+        this.robot.reply({}, 'test message')
+        expect(this.robot.adapter.reply).to.have.been.calledOn(this.robot.adapter)
+      })
+    })
+
+    describe('#messageRoom', function () {
+      beforeEach(function () {
+        sinon.spy(this.robot.adapter, 'send')
+      })
+
+      it('delegates to adapter "send" with proper context', function () {
+        this.robot.messageRoom('testRoom', 'messageRoom test')
+        expect(this.robot.adapter.send).to.have.been.calledOn(this.robot.adapter)
+      })
+    })
+
+    describe('#on', function () {
+      beforeEach(function () {
+        sinon.spy(this.robot.events, 'on')
+      })
+
+      it('delegates to events "on" with proper context', function () {
+        this.robot.on('event', function () {})
+        expect(this.robot.events.on).to.have.been.calledOn(this.robot.events)
+      })
+    })
+
+    describe('#emit', function () {
+      beforeEach(function () {
+        sinon.spy(this.robot.events, 'emit')
+      })
+
+      it('delegates to events "emit" with proper context', function () {
+        this.robot.emit('event', function () {})
+        expect(this.robot.events.emit).to.have.been.calledOn(this.robot.events)
+      })
+    })
   })
 
   describe('Listener Registration', function () {


### PR DESCRIPTION
Robot 'send', 'reply', 'messageRoom' methods delegate invocations to
adapter but using as 'this' the robot while they should be using the adapter.
Robot 'on', 'emit' methods delegate invocations to events but using as
'this' the robot but they should be using the events.

The original CoffeeScript code from release 2.19.0 uses simple delegation, i.e. [send](https://github.com/hubotio/hubot/blob/c0f6bdf947c5271c2cac5d48730320b129c2e44f/src/robot.coffee#L542), [reply](https://github.com/hubotio/hubot/blob/c0f6bdf947c5271c2cac5d48730320b129c2e44f/src/robot.coffee#L552), [messageRoom](https://github.com/hubotio/hubot/blob/c0f6bdf947c5271c2cac5d48730320b129c2e44f/src/robot.coffee#L562), [on](https://github.com/hubotio/hubot/blob/c0f6bdf947c5271c2cac5d48730320b129c2e44f/src/robot.coffee#L573), [emit](https://github.com/hubotio/hubot/blob/c0f6bdf947c5271c2cac5d48730320b129c2e44f/src/robot.coffee#L583). This PR should address #1386.