### PR TITLE
Update mocha call to prevent deprecation warning

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -918,7 +918,7 @@ describe 'example script', ->
 
 **sample output**
 ```bash
-% mocha --compilers "coffee:coffee-script/register" test/*.coffee
+% mocha --require coffee-script/register test/*.coffee
 
 
   example script


### PR DESCRIPTION
the --compilers flag is deprecated and will be removed in a future version of Mocha
https://github.com/mochajs/mocha/wiki/compilers-deprecation

Using the --require flag instead