### PR TITLE
chore(*) add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Match and apply these rules for all file
+# types you open in your code editor
+[*]
+# Unix-style newlines
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
[editorconfig](http://editorconfig.org/) is a great way to set some file formatting conventions for a project and have your text editor automatically apply them. Though many linters like eslint or standard should detect those with the right rules enabled, this tells the user's editor the right way to do it and saves the hassle of failed tests because of simple indentation issues or Windows-created files with CRLF line endings.