### PR TITLE
Set max json request body size with EXPRESS_LIMIT

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -441,7 +441,7 @@ class Robot {
     }
     app.use(express.query())
 
-    app.use(express.json())
+    app.use(express.json({ limit }))
     app.use(express.urlencoded({ limit, parameterLimit: paramLimit }))
     // replacement for deprecated express.multipart/connect.multipart
     // limit to 100mb, as per the old behavior


### PR DESCRIPTION
Extends #1106 to include JSON requests.

Background: I pipe GitHub "push" events to hubot (using `content-type: application/json`) and every now and again express returns 413 Payload Too Large if the push contains a lot of commits. I found the new `EXPRESS_LIMIT` env var, but it only applies to urlencoded requests. The name of this env var suggests that it's not specific to any one content type in particular, so I'm hoping it's OK to apply this limit to JSON requests too! No new documentation required, as the current wording doesn't specifically mention urlencoded requests.