### PR TITLE
Doc parser: don't strip comment leader twice

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -524,7 +524,7 @@ class Robot {
     const body = fs.readFileSync(require.resolve(path), 'utf-8')
 
     const useStrictHeaderRegex = /^["']use strict['"];?\s+/
-    const lines = body.replace(useStrictHeaderRegex, '').split('\n')
+    const lines = body.replace(useStrictHeaderRegex, '').split(/(?:\n|\r\n|\r)/)
       .reduce(toHeaderCommentBlock, {lines: [], isHeader: true}).lines
       .filter(Boolean) // remove empty lines
     let currentSection = null


### PR DESCRIPTION
This fixes a bug I encountered when upgrading a Hubot application with some scripts which used the deprecated documentation syntax. The comment leader is already stripped by the time Hubot hits the `if (currentSection === null)` loop, so the `.slice` strips the leading two characters which contain actual text. For example, here's how this line gets parsed:

```
#   hubot translate me <phrase> - The 'me' is optional
```

Before:

`bot translate me <phrase> - The 'me' is optional`

After:

`hubot translate me <phrase> - The 'me' is optional`