### PR TITLE
Fix grammar in adapters doc

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -11,7 +11,7 @@ Hubot includes two official adapters:
 * [Shell](./adapters/shell.md), i.e. for use with development
 * [Campfire](./adapters/campfire.md)
 
-There are Third-party adapaters are available for most chat services. Here are the most popular ones:
+Third-party adapters are available for most chat services. Here are the most popular ones:
 
 * [Gitter](https://github.com/huafu/hubot-gitter2)
 * [HipChat](https://github.com/hipchat/hubot-hipchat)


### PR DESCRIPTION
This PR is just a simple edit of a typo and grammar on the Hubot adapters page in the documentation.