### PR TITLE
updated heroku deploy links

### DIFF
--- a/docs/deploying/heroku.md
+++ b/docs/deploying/heroku.md
@@ -7,7 +7,7 @@ permalink: /docs/deploying/heroku/
 If you've been following along with [Getting Started](../index.md), it's time to deploy so you can use it beyond just your local machine.
 [Heroku](http://www.heroku.com/) is an easy and supported way to deploy hubot.
 
-Install the [Heroku Toolbelt](https://toolbelt.heroku.com/) to start, then follow their 'Getting Started' instructions, including logging in the first time:
+Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) to start, then follow their '[Getting Started](https://devcenter.heroku.com/articles/heroku-cli#getting-started)' instructions, including logging in the first time:
 
     % heroku login
     Enter your Heroku credentials.


### PR DESCRIPTION
👋 I'm going through documenting Hubot for some friends and coworkers and noticed some links not being correct (though the redirects work!).

