### PR TITLE
Bump express and connect-multiparty

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "chalk": "^1.0.0",
     "cline": "^0.8.2",
     "coffee-script": "1.6.3",
-    "connect-multiparty": "^1.2.5",
-    "express": "^3.21.2",
+    "connect-multiparty": "^2.1.1",
+    "express": "^4.16.3",
     "log": "1.4.0",
     "optparse": "1.0.4",
     "scoped-http-client": "0.11.0"


### PR DESCRIPTION
These two dependencies were lagging behind the current published versions.

According to the [express migration guide](https://github.com/expressjs/express/wiki/Migrating-from-3.x-to-4.x), it doesn't look like Hubot hits any of the pain points there. The tests are also passing.