### PR TITLE
chore(travis): drop Node 4, add Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "10"
   - "8"
   - "6"
-  - "4"
 notifications:
   email: false
 sudo: false


### PR DESCRIPTION
As discussed in https://github.com/hubotio/hubot/pull/1453#issuecomment-410030443, Node 4 has been EOLed and the build isn't currently succeeding on it. This drops Node 4 from the Travis builds and adds Node 10 instead.