### PR TITLE
CI: Use updated method of using semantic-release with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,11 @@ before_script:
   - bin/e2e-test.sh
 after_success:
   - npm run coverage
-  - npm run semantic-release
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx travis-deploy-once "npx semantic-release"


### PR DESCRIPTION
semantic-release didn't seem to fire as expected in https://github.com/hubotio/hubot/pull/1453 . There are updated instructions about semantic-release on travis: https://github.com/semantic-release/semantic-release/blob/b082a2eb38368d400a86049b019d9baec6eef8f0/docs/recipes/travis.md#using-semantic-release-with-travis-ci