### PR TITLE
travis: update npm before running npx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ deploy:
   provider: script
   skip_cleanup: true
   script:
+    - npm install -g npm@latest
     - npx travis-deploy-once "npx semantic-release"


### PR DESCRIPTION
Alternative to #1456.

npx is a part of npm itself as of 5.2.0, so this is probably the best way to make sure npx is available to us later in the script.