### PR TITLE
CI: Another attempt to fix release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
   apt:
     packages:
     - expect
+before_install:
+  - npm install -g npm@latest
 before_script:
   - npm prune
   - bin/e2e-test.sh


### PR DESCRIPTION
The deploy stage failed initially because npx wasn't found. This is a feature introduced in npm 5.2, which it seems node 6 doesn't have.

This might be better than upgrading npm at deploy time, because we can see failures from it earlier on.

Another variation of https://github.com/hubotio/hubot/pull/1456 or https://github.com/hubotio/hubot/pull/1457 😅 