### PR TITLE
Chore: Publish to default tag instead of next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "hubot",
   "version": "0.0.0-development",
-  "publishConfig": {
-    "tag": "next"
-  },
   "author": "hubot",
   "keywords": [
     "github",


### PR DESCRIPTION
I was wondering why semantic-release was publishing to `next` 😅 