### PR TITLE
chore(package): Move coffee-scirpt to coffeescript

### DIFF
--- a/docs/adapters/development.md
+++ b/docs/adapters/development.md
@@ -52,7 +52,7 @@ exports.use = (robot) ->
     "hubot": ">=2.0"
   },
   "devDependencies": {
-    "coffee-script": ">=1.2.0"
+    "coffeescript": ">=1.2.0"
   }
   ```
 

--- a/docs/deploying/azure.md
+++ b/docs/deploying/azure.md
@@ -40,7 +40,7 @@ Then, edit this file and look for the sections that give you steps 1, 2 and 3. Y
 
 Now, create a new file in the base directory of hubot called `server.js` and put these two lines into it:
 
-    require('coffee-script/register');
+    require('coffeescript/register');
     module.exports = require('hubot/bin/hubot.coffee');
 
 Finally you will need to add the environment variables to the website to make sure it runs properly. You can either do it through the GUI (under configuration) or you can use the Azure PowerShell command line, as follows (example is showing slack as an adapter and mynewhubot as the website name).

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -871,12 +871,12 @@ You'll also need to install:
 
 You may also want to install:
 
- * *coffee-script* (if you're writing your tests in CoffeeScript rather than JavaScript)
+ * *coffeescript* (if you're writing your tests in CoffeeScript rather than JavaScript)
  * a mocking library such as *Sinon.js* (if your script performs webservice calls or
    other asynchronous actions)
 
 Here is a sample script that tests the first couple of commands in the
-[Hubot sample script](https://github.com/hubotio/generator-hubot/blob/master/generators/app/templates/scripts/example.coffee).  This script uses *Mocha*, *chai*, *coffee-script*, and of course *hubot-test-helper*:
+[Hubot sample script](https://github.com/hubotio/generator-hubot/blob/master/generators/app/templates/scripts/example.coffee).  This script uses *Mocha*, *chai*, *coffeescript*, and of course *hubot-test-helper*:
 
 **test/example-test.coffee**
 ```coffeescript
@@ -918,7 +918,7 @@ describe 'example script', ->
 
 **sample output**
 ```bash
-% mocha --require coffee-script/register test/*.coffee
+% mocha --require coffeescript/register test/*.coffee
 
 
   example script

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "async": ">=0.1.0 <1.0.0",
     "chalk": "^1.0.0",
     "cline": "^0.8.2",
-    "coffee-script": "1.6.3",
+    "coffeescript": "1.6.3",
     "connect-multiparty": "^2.1.1",
     "express": "^4.16.3",
     "log": "1.4.0",


### PR DESCRIPTION
#1462 
`npm WARN deprecated coffee-script@1.6.3: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)`