### PR TITLE
chore(package): Upgrade nyc to the 13.x series

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coveralls": "^2.13.1",
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",
-    "nyc": "^11.0.2",
+    "nyc": "^13.0.0",
     "semantic-release": "^15.9.3",
     "sinon": "~1.17.0",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
This gets us on the latest version of `nyc`.

Verified that both `script/test` and `npm run test` still worked correctly. I was unable to verify that `npm run coverage` wasn't broken locally and am operating under the assumption that it will be tested via this pull request.