### PR TITLE
docs(src/robot.js): add comment for alias

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -25,6 +25,7 @@ class Robot {
   // adapter     - A String of the adapter name.
   // httpd       - A Boolean whether to enable the HTTP daemon.
   // name        - A String of the robot name, defaults to Hubot.
+  // alias       - A String of the alias of the robot name
   constructor (adapterPath, adapter, httpd, name, alias) {
     if (name == null) {
       name = 'Hubot'


### PR DESCRIPTION
Dear hubot team,

I found that a comment for alias which is one of arguments of Robot constructor.
So, I added it.

Could you consider accepting this small doc patch?