### PR TITLE
Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "chai": "~2.1.0",
-    "coveralls": "^2.13.1",
+    "coveralls": "^3.0.2",
     "mocha": "^5.2.0",
     "mockery": "^1.4.0",
     "nyc": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "~2.1.0",
     "coveralls": "^2.13.1",
-    "mocha": "^2.1.0",
+    "mocha": "^5.2.0",
     "mockery": "^1.4.0",
     "nyc": "^11.0.2",
     "semantic-release": "^15.9.3",


### PR DESCRIPTION
This makes a few changes to Hubot's dependencies:

* `coffee-script` has moved to `coffeescript`. The old name still works, but this silences an npm warning.
* Bump to the latest versions of both `mocha` and `coveralls`, both of which had lagged a bit behind upstream. Thankfully the tests run as-is without requiring changes.