### PR TITLE
Adapter docs: document ES2015 entry point

### DIFF
--- a/docs/adapters/development.md
+++ b/docs/adapters/development.md
@@ -6,7 +6,19 @@ permalink: /docs/adapters/development/
 
 ## Adapter Basics
 
-All adapters inherit from the Adapter class in the `src/adapter.coffee` file.  There are certain methods that you will want to override.  Here is a basic stub of what an extended Adapter class would look like:
+All adapters inherit from the Adapter class in the `src/adapter.coffee` file.  If you're writing your adapter in CoffeeScript, require the primary version of the adapter:
+
+```coffee
+Adapter = require('hubot').Adapter
+```
+
+If you're writing your adapter in ES2015, you must require the ES2015 entrypoint instead:
+
+```js
+const Adapter = require('hubot/es2015').Adapter;
+```
+
+There are certain methods that you will want to override.  Here is a basic stub of what an extended Adapter class would look like:
 
 ```coffee
 class Sample extends Adapter


### PR DESCRIPTION
The default Hubot require entrypoint is only compatible with CoffeeScript. A separate entrypoint has to be used when writing ES2015 classes. This isn't currently documented; I got bit by this when writing an ES2015 class that extends a Hubot class, and it took me awhile to track down the comment that mentions it: https://github.com/hubotio/evolution/pull/4#issuecomment-306437501