### PR TITLE
Brain: ensure User objects are actually User objects

### DIFF
--- a/test/brain_test.js
+++ b/test/brain_test.js
@@ -58,6 +58,14 @@ describe('Brain', function () {
         this.brain.mergeData({})
         expect(this.brain.emit).to.have.been.calledWith('loaded', this.brain.data)
       })
+
+      it('coerces loaded data into User objects', function () {
+        this.brain.mergeData({users: {'4': {'name': 'new', 'id': '4'}}})
+        let user = this.brain.userForId('4')
+        expect(user.constructor.name).to.equal('User')
+        expect(user.id).to.equal('4')
+        expect(user.name).to.equal('new')
+      })
     })
 
     describe('#save', () => it('emits a save event', function () {
@@ -307,6 +315,17 @@ describe('Brain', function () {
       const result = this.brain.usersForFuzzyName('Guy')
       expect(result).to.have.members([this.user1, this.user2])
       expect(result).to.not.have.members([this.user3])
+    })
+
+    it('returns User objects, not POJOs', function () {
+      expect(this.brain.userForId('1').constructor.name).to.equal('User')
+      for (let user of this.brain.usersForFuzzyName('Guy')) {
+        expect(user.constructor.name).to.equal('User')
+      }
+
+      for (let user of this.brain.usersForRawFuzzyName('Guy One')) {
+        expect(user.constructor.name).to.equal('User')
+      }
     })
   })
 })


### PR DESCRIPTION
While the brain consistently documents that its functions return `User` objects, this actually isn't guaranteed. If the data is serialized to JSON for persisting - [like the Redis brain does](https://github.com/hubotio/hubot-redis-brain/blob/master/src/redis-brain.js#L93) - then `User` objects are serialized as plain JS objects and parsed back as them too. This leads to a mix of plain JS objects and actual `User` instances. This can lead to confusion, and it's also causing problems with an in-development branch of mine which grants instance methods to `User` objects.

This PR resolves this by turning plain objects back into `User` objects in `mergeData` before calling `loaded`. The new objects retain all the properties of the original ones, ensuring they're consistent with any newly-constructed objects created at runtime.

cc @technicalpickles 