### PR TITLE
fix: address deprecation warning on startup

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -444,7 +444,7 @@ class Robot {
     app.use(express.query())
 
     app.use(express.json())
-    app.use(express.urlencoded({ limit, parameterLimit: paramLimit, extended: false }))
+    app.use(express.urlencoded({ limit, parameterLimit: paramLimit, extended: true }))
     // replacement for deprecated express.multipart/connect.multipart
     // limit to 100mb, as per the old behavior
     app.use(multipart({ maxFilesSize: 100 * 1024 * 1024 }))

--- a/src/robot.js
+++ b/src/robot.js
@@ -444,7 +444,7 @@ class Robot {
     app.use(express.query())
 
     app.use(express.json())
-    app.use(express.urlencoded({ limit, parameterLimit: paramLimit }))
+    app.use(express.urlencoded({ limit, parameterLimit: paramLimit, extended: false }))
     // replacement for deprecated express.multipart/connect.multipart
     // limit to 100mb, as per the old behavior
     app.use(multipart({ maxFilesSize: 100 * 1024 * 1024 }))


### PR DESCRIPTION
The `body-parser` deprecation warning on startup is due to `express.urlencode()`
requiring an `extended` property in the options argument in Express 4.x.

Fixes: https://github.com/hubotio/hubot/issues/1476