### PR TITLE
feat: Robot constructor to take an object of properties

### DIFF
--- a/bin/hubot.js
+++ b/bin/hubot.js
@@ -23,7 +23,7 @@ const options = {
   adapter: process.env.HUBOT_ADAPTER || 'shell',
   alias: process.env.HUBOT_ALIAS || false,
   create: process.env.HUBOT_CREATE || false,
-  enableHttpd: process.env.HUBOT_HTTPD || true,
+  httpd: process.env.HUBOT_HTTPD || true,
   scripts: process.env.HUBOT_SCRIPTS || [],
   name: process.env.HUBOT_NAME || 'Hubot',
   path: process.env.HUBOT_PATH || '.',
@@ -43,7 +43,7 @@ Parser.on('create', function (opt, value) {
 })
 
 Parser.on('disable-httpd', opt => {
-  options.enableHttpd = false
+  options.httpd = false
 })
 
 Parser.on('help', function (opt, value) {
@@ -94,7 +94,7 @@ if (options.create) {
   process.exit(1)
 }
 
-const robot = Hubot.loadBot(undefined, options.adapter, options.enableHttpd, options.name, options.alias)
+const robot = Hubot.Robot(options)
 
 if (options.version) {
   console.log(robot.version)

--- a/es2015.js
+++ b/es2015.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const deprecate = require('depd')('hubot')
+
 const User = require('./src/user')
 const Brain = require('./src/brain')
 const Robot = require('./src/robot')
@@ -24,6 +26,8 @@ module.exports = {
   CatchAllMessage: Message.CatchAllMessage,
 
   loadBot (adapterPath, adapterName, enableHttpd, botName, botAlias) {
-    return new module.exports.Robot(adapterPath, adapterName, enableHttpd, botName, botAlias)
+    deprecate('use Hubot.Robot constructor directly instead of Hubot.loadBot')
+
+    return new module.exports.Robot({adapter: adapterName, httpd: enableHttpd, name: botName, alias: botAlias})
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cline": "^0.8.2",
     "coffee-script": "1.6.3",
     "connect-multiparty": "^1.2.5",
+    "depd": "^1.1.0",
     "express": "^3.21.2",
     "log": "1.4.0",
     "optparse": "1.0.4",

--- a/test/es2015_test.js
+++ b/test/es2015_test.js
@@ -194,6 +194,6 @@ describe('hubot/es2015', function () {
 
     expect(loadBot).to.be.a('function')
     Hubot.loadBot('adapterPath', 'adapterName', 'enableHttpd', 'botName', 'botAlias')
-    expect(Hubot.Robot).to.be.called.calledWith('adapterPath', 'adapterName', 'enableHttpd', 'botName', 'botAlias')
+    expect(Hubot.Robot).to.be.called.calledWith({adapter: 'adapterName', httpd: 'enableHttpd', name: 'botName', alias: 'botAlias'})
   })
 })

--- a/test/middleware_test.js
+++ b/test/middleware_test.js
@@ -351,7 +351,7 @@ describe('Middleware', function () {
         warnOnUnregistered: false
       })
       mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter'))
-      this.robot = new Robot(null, 'mock-adapter', true, 'TestHubot')
+      this.robot = new Robot({adapter: 'mock-adapter', httpd: false, name: 'TestHubot'})
       this.robot.run
 
       // Re-throw AssertionErrors for clearer test failures

--- a/test/robot_test.js
+++ b/test/robot_test.js
@@ -28,8 +28,7 @@ describe('Robot', function () {
       warnOnUnregistered: false
     })
     mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter'))
-    this.robot = new Robot(null, 'mock-adapter', true, 'TestHubot')
-    this.robot.alias = 'Hubot'
+    this.robot = new Robot({adapter: 'mock-adapter', httpd: false, name: 'TestHubot', alias: 'Hubot'})
     this.robot.run()
 
     // Re-throw AssertionErrors for clearer test failures
@@ -1009,5 +1008,28 @@ describe('Robot', function () {
         })
       })
     })
+  })
+})
+
+describe('Robot deprecated constructor', function () {
+  beforeEach(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false
+    })
+    mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter'))
+  })
+
+  afterEach(function () {
+    mockery.disable()
+    this.robot.shutdown()
+  })
+
+  it('works but is deprecated', function () {
+    this.robot = new Robot(null, 'mock-adapter', false, 'TestHubot', 'Hubot')
+    expect(this.robot.adapterName).to.equal('mock-adapter')
+    // TODO test that false got passed in? that value isn't set, instead it determines if null route setup or not
+    expect(this.robot.name).to.equal('TestHubot')
+    expect(this.robot.alias).to.equal('Hubot')
   })
 })


### PR DESCRIPTION
Previously, Robot took positional arguments. This is fine for internal
use, but when programatically building, it looks weird because you have
a bunch of null and boolean values which don't make sense on their own.
It is bad for the reasons having multiple positional arguments is bad,
lack of readability.

Instead of positional arguments, this updates Robot to take an options
object, so the parameters are named and it is clear to a reader what
each does.

This continues to support the old positional arguments, but emits a
deprecation message with depd. Internal use of has been updated to use
the options object, and there probably aren't a ton of uses of Robot
directly in the wild (although there is definitely at least
hubot-test-helper). This support can be considered for removal during
the next breaking release.

This is part of https://github.com/hubotio/evolution/pull/3