### PR TITLE
fix: address TypeError by Experss

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -434,7 +434,7 @@ class Robot {
     const app = express()
 
     app.use((req, res, next) => {
-      res.setHeader('X-Powered-By', `hubot/${this.name}`)
+      res.setHeader('X-Powered-By', `hubot/${encodeURI(this.name)}`)
       return next()
     })
 


### PR DESCRIPTION
When hubot's name is multibyte character, Hubot's router crashes with the following error because Express tries to set hubot's name in response header.
```
TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["X-Powered-By"]
  at validateHeader (_http_outgoing.js:506:11)
  at ServerResponse.setHeader (_http_outgoing.js:510:3)
  at app.use (/home/bot/node_modules/hubot/src/robot.js:436:11)
```

In this pull request, the error is avoided by encoding hubot's name.