### PR TITLE
fix: fixed to version before dropped support for Node 6

### DIFF
--- a/bin/e2e-test.sh
+++ b/bin/e2e-test.sh
@@ -8,8 +8,8 @@ trap "{ CODE=$?; popd; rm -rf $TEMP_ROOT; exit $CODE; }" EXIT
 
 ## https://hubot.github.com/docs/
 
-echo "$ npm install -g yo generator-hubot"
-npm install -g yo generator-hubot
+echo "$ npm install -g yo@2.0.6 generator-hubot"
+npm install -g yo@2.0.6 generator-hubot
 
 ## simulate pressing enter for each generator question to accept defaults
 ## https://stackoverflow.com/a/6264618/206879


### PR DESCRIPTION
`yeoman` dropped support for Node 6 in version 3.x.
So, `yeoman` for testing is specified as the previous version by this pull request.

https://github.com/yeoman/yo/tree/v3.0.0

Because this fix prioritized running on node version 6.X for testing purposes, 
in the future, hubot should consider removing node version 6.x from testing or not use `yeoman`.