### PR TITLE
Update copyright date to 2020

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2017 GitHub Inc.
+Copyright (c) 2011-2020 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
This file is referenced in the [GitHub docs](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/licensing-a-repository) as an examplar licence. I figured it was worth therefore keeping it up to date :)