### PR TITLE
fix: HUBOT_HTTPD can now disable httpd

### DIFF
--- a/bin/hubot.js
+++ b/bin/hubot.js
@@ -23,7 +23,7 @@ const options = {
   adapter: process.env.HUBOT_ADAPTER || 'shell',
   alias: process.env.HUBOT_ALIAS || false,
   create: process.env.HUBOT_CREATE || false,
-  enableHttpd: process.env.HUBOT_HTTPD || true,
+  enableHttpd: process.env.HUBOT_HTTPD !== 'false',
   scripts: process.env.HUBOT_SCRIPTS || [],
   name: process.env.HUBOT_NAME || 'Hubot',
   path: process.env.HUBOT_PATH || '.',


### PR DESCRIPTION
This is a fix for https://github.com/hubotio/hubot/issues/1471. The approach taken here is to compare the `HUBOT_HTTPD` environment variable to the string `'false'` and then assign the value of this comparison to the `enableHttpd` option. This ensures that a boolean value is always passed to the robot constructor (which it already assumes).

The effect here is that setting `HUBOT_HTTPD` to `'false'` will disable httpd, but all other values will enable it. The only backwards compatibility issues caused by this change would be if someone happened to already have `HUBOT_HTTPD=false` in their configuration; with this new change they would find that httpd would actually be disabled now. I wasn't sure if that was enough to officially consider this a breaking change, so I labelled this as a fix.