### PR TITLE
chore(package): bump async

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/hubotio/hubot.git"
   },
   "dependencies": {
-    "async": ">=0.1.0 <1.0.0",
+    "async": "^2.6.4",
     "chalk": "^1.0.0",
     "cline": "^0.8.2",
     "coffeescript": "1.6.3",


### PR DESCRIPTION
Of the version that fix CVE-2021-43138, tests passed with 2.6.4 and failed with 3.2.2.