### PR TITLE
fix(httpclient): #1584 remove trailiing spaces

### DIFF
--- a/src/httpclient.js
+++ b/src/httpclient.js
@@ -280,7 +280,6 @@ class ScopedClient {
       }
       i += 1
     }
-    
     if (!options.headers) { options.headers = {} }
     if (options.encoding == null) { options.encoding = 'utf-8' }
     return options


### PR DESCRIPTION
The build failed due to trailing spaces. This removes the spaces.