### PR TITLE
chore: Tests not exiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "chai": "~2.1.0",
-    "coveralls": "^3.0.2",
+    "coveralls": "^3.1.1",
     "is-circular": "^1.0.2",
     "mocha": "^10.2.0",
     "mockery": "^1.4.0",
@@ -48,7 +48,7 @@
   "scripts": {
     "start": "bin/hubot",
     "pretest": "standard",
-    "test": "nyc --reporter=html --reporter=text mocha",
+    "test": "nyc --reporter=html --reporter=text mocha --exit",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test:smoke": "node src/**/*.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"


### PR DESCRIPTION
At version 4.0.0, Mocha changed the default behavior from exiting after tests were complete to not exiting. From that point on, you must add the --exit flag if you want mocha to stop when tests have been run.

#1607 

Given you're running Node.js version >=v18
and you've run `npm install`
When you run `npm test`
Then the tests execute but fails to exit the process