### PR TITLE
chore(package): bump async to version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "async": ">=0.1.0 <1.0.0",
+        "async": "^3.2.4",
         "chalk": "^1.0.0",
         "cline": "^0.8.2",
         "coffeescript": "1.6.3",
@@ -1341,9 +1341,9 @@
       }
     },
     "node_modules/async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -12245,9 +12245,9 @@
       "dev": true
     },
     "async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/hubotio/hubot.git"
   },
   "dependencies": {
-    "async": ">=0.1.0 <1.0.0",
+    "async": "^3.2.4",
     "chalk": "^1.0.0",
     "cline": "^0.8.2",
     "coffeescript": "1.6.3",

--- a/src/robot.js
+++ b/src/robot.js
@@ -317,13 +317,13 @@ class Robot {
           // stack doesn't get too big
           process.nextTick(() =>
             // Stop processing when message.done == true
-            done(context.response.message.done)
+            done(null, context.response.message.done)
           )
         })
       } catch (err) {
         this.emit('error', err, new this.Response(this, context.response.message, []))
         // Continue to next listener when there is an error
-        done(false)
+        done(null, false)
       }
     },
     // Ignore the result ( == the listener that set message.done = true)


### PR DESCRIPTION
# Intent

#1605  Update dependencies to the latest versions

# Approach

The tests were timing out when updating `async` to v3.2.4. After investigating, the problem was that the `async.detectSeries` callback was not executing unless `message.done` was set to `true` in a Hubot Listener.

This [SO](https://stackoverflow.com/questions/42248993/how-to-return-output-in-node-using-async-detect-series) question and answer lead me to the issue.

