### PR TITLE
Very minor removal of extraneous character in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,3 @@ are building your own bot. But if you do, check out [CONTRIBUTING.md](CONTRIBUTI
 ## License
 
 See the [LICENSE](LICENSE.md) file for license rights and limitations (MIT).
-`


### PR DESCRIPTION
This removes the extraneous backtick character at the end of the readme.

It appears to have been recently added accidentally in #1604.