### PR TITLE
feat(adapter): Load adapter from local disk

### DIFF
--- a/bin/hubot.js
+++ b/bin/hubot.js
@@ -101,7 +101,6 @@ function loadScripts () {
   robot.load(pathResolve('.', 'scripts'))
   robot.load(pathResolve('.', 'src', 'scripts'))
 
-  loadHubotScripts()
   loadExternalScripts()
 
   options.scripts.forEach((scriptPath) => {
@@ -111,70 +110,6 @@ function loadScripts () {
 
     robot.load(pathResolve('.', scriptPath))
   })
-}
-
-function loadHubotScripts () {
-  const hubotScripts = pathResolve('.', 'hubot-scripts.json')
-  let scripts
-  let scriptsPath
-
-  if (fs.existsSync(hubotScripts)) {
-    let hubotScriptsWarning
-    const data = fs.readFileSync(hubotScripts)
-
-    if (data.length === 0) {
-      return
-    }
-
-    try {
-      scripts = JSON.parse(data)
-      scriptsPath = pathResolve('node_modules', 'hubot-scripts', 'src', 'scripts')
-      robot.loadHubotScripts(scriptsPath, scripts)
-    } catch (error) {
-      const err = error
-      robot.logger.error(`Error parsing JSON data from hubot-scripts.json: ${err}`)
-      process.exit(1)
-    }
-
-    hubotScriptsWarning = 'Loading scripts from hubot-scripts.json is deprecated and ' + 'will be removed in 3.0 (https://github.com/github/hubot-scripts/issues/1113) ' + 'in favor of packages for each script.\n\n'
-
-    if (scripts.length === 0) {
-      hubotScriptsWarning += 'Your hubot-scripts.json is empty, so you just need to remove it.'
-      return robot.logger.warning(hubotScriptsWarning)
-    }
-
-    const hubotScriptsReplacements = pathResolve('node_modules', 'hubot-scripts', 'replacements.json')
-    const replacementsData = fs.readFileSync(hubotScriptsReplacements)
-    const replacements = JSON.parse(replacementsData)
-    const scriptsWithoutReplacements = []
-
-    if (!fs.existsSync(hubotScriptsReplacements)) {
-      hubotScriptsWarning += 'To get a list of recommended replacements, update your hubot-scripts: npm install --save hubot-scripts@latest'
-      return robot.logger.warning(hubotScriptsWarning)
-    }
-
-    hubotScriptsWarning += 'The following scripts have known replacements. Follow the link for installation instructions, then remove it from hubot-scripts.json:\n'
-
-    scripts.forEach((script) => {
-      const replacement = replacements[script]
-
-      if (replacement) {
-        hubotScriptsWarning += `* ${script}: ${replacement}\n`
-      } else {
-        scriptsWithoutReplacements.push(script)
-      }
-    })
-
-    hubotScriptsWarning += '\n'
-
-    if (scriptsWithoutReplacements.length > 0) {
-      hubotScriptsWarning += 'The following scripts don’t have (known) replacements. You can try searching https://www.npmjs.com/ or http://github.com/search or your favorite search engine. You can copy the script into your local scripts directory, or consider creating a new package to maintain yourself. If you find a replacement or create a package yourself, please post on https://github.com/github/hubot-scripts/issues/1641:\n'
-      hubotScriptsWarning += scriptsWithoutReplacements.map((script) => `* ${script}\n`).join('')
-      hubotScriptsWarning += '\nYou an also try updating hubot-scripts to get the latest list of replacements: npm install --save hubot-scripts@latest'
-    }
-
-    robot.logger.warning(hubotScriptsWarning)
-  }
 }
 
 function loadExternalScripts () {

--- a/bin/hubot.js
+++ b/bin/hubot.js
@@ -100,7 +100,6 @@ if (options.file) {
 const robot = Hubot.loadBot(options.adapter, options.enableHttpd, options.name, options.alias)
 
 function loadScripts () {
-  console.log('loading scripts')
   robot.load(pathResolve('.', 'scripts'))
   robot.load(pathResolve('.', 'src', 'scripts'))
 

--- a/docs/adapters/development.md
+++ b/docs/adapters/development.md
@@ -33,7 +33,7 @@ class Sample extends Adapter {
     }
     run() {
         this.robot.logger.info('Run')
-        this.emit('connected') // this line is required. Scripts won't get loadded if this event never fires.
+        this.emit('connected') // The 'connected' event is required to trigger loading of Hubot scripts.
         const user = new User(1001, 'Sample User')
         const message = new TextMessage(user, 'Some Sample Message', 'MSG-001')
         this.robot.receive(message)

--- a/docs/adapters/development.md
+++ b/docs/adapters/development.md
@@ -33,7 +33,7 @@ class Sample extends Adapter {
     }
     run() {
         this.robot.logger.info('Run')
-        this.emit('connected')
+        this.emit('connected') // this line is required. Scripts won't get loadded if this event never fires.
         const user = new User(1001, 'Sample User')
         const message = new TextMessage(user, 'Some Sample Message', 'MSG-001')
         this.robot.receive(message)
@@ -42,23 +42,23 @@ class Sample extends Adapter {
 exports.use = (robot) => new Sample(robot)
 ```
 
-## Setting Up Your Development Environment
+## Option 1. Setting Up Your Development Environment
 
 1. Create a new folder for your adapter `hubot-sample`
   - `mkdir hubot-sample`
 2. Change your working directory to `hubot-sample`
   - `cd hubot-sample`
 3. Run `npm init` to create your package.json
-  - make sure the entry point is `src/sample.coffee`
+  - make sure the entry point is `src/sample.js`
 4. Add your `.gitignore` to include `node_modules`
-5. Edit the `src/sample.coffee` file to include the above stub for your adapter
+5. Edit the `src/sample.js` file to include the above stub for your adapter
 6. Edit the `package.json` to add a peer dependency on `hubot`
 
   ```json
   "dependencies": {
   },
   "peerDependencies": {
-    "hubot": ">=2.0"
+    "hubot": ">=3.0"
   },
   "devDependencies": {
     "coffeescript": ">=1.2.0"
@@ -96,3 +96,30 @@ There is a an open issue in the node community around [npm linked peer dependenc
 3. Now try running `hubot -a sample` again and see that the imports are properly loaded.
 4. Once this is working properly, you can build out the functionality of your adapter as you see fit.  Take a look at some of the other adapters to get some ideas for your implementation.
   - Once packaged and deployed via `npm`, you won't need the dependency in `hubot` anymore since the peer dependency should work as an official module.
+
+## Option 2. Setting Up Your Development Environment
+
+Another option is to load the file from local disk.
+
+1. Create a new folder for your adapter `hubot-sample`
+  - `mkdir hubot-sample`
+2. Change your working directory to `hubot-sample`
+  - `cd hubot-sample`
+3. Run `npm init` to create your package.json
+  - make sure the entry point is `src/sample.js`
+4. Add your `.gitignore` to include `node_modules`
+5. Edit the `src/sample.js` file to include the above stub for your adapter
+6. Edit the `package.json` to add a peer dependency on `hubot`
+
+  ```json
+  "dependencies": {
+  },
+  "peerDependencies": {
+    "hubot": ">=4.2.0"
+  },
+  "devDependencies": {
+    "coffeescript": ">=1.2.0"
+  }
+  ```
+
+7. Run `npx hubot -p ./src -a sample.js`

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict'
+require('coffeescript/register')
 
 const inherits = require('util').inherits
 

--- a/src/robot.js
+++ b/src/robot.js
@@ -504,7 +504,6 @@ class Robot {
   //
   // Returns nothing.
   async loadAdapter (adapterPath = null) {
-    
     this.logger.debug(`Loading adapter ${adapterPath ?? 'from npmjs:'} ${this.adapterName}`)
     const ext = path.extname(adapterPath ?? '') ?? '.js'
     try {

--- a/test/adapter_test.js
+++ b/test/adapter_test.js
@@ -15,9 +15,6 @@ describe('Adapter', function () {
     this.robot = { receive: sinon.spy() }
   })
 
-  // this one is hard, as it requires files
-  it('can load adapter by name')
-
   describe('Public API', function () {
     beforeEach(function () {
       this.adapter = new Adapter(this.robot)

--- a/test/es2015_test.js
+++ b/test/es2015_test.js
@@ -52,16 +52,16 @@ describe('hubot/es2015', function () {
     expect(brain.get('foo')).to.equal('bar')
   })
 
-  it('exports Robot class', function () {
+  it('exports Robot class', async function () {
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false
     })
-    mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter'))
+    mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
 
     class MyRobot extends Robot {}
     const robot = new MyRobot(null, 'mock-adapter', false, 'TestHubot')
-
+    await robot.loadAdapter()
     expect(robot).to.be.an.instanceof(Robot)
     expect(robot.name).to.equal('TestHubot')
 
@@ -193,7 +193,7 @@ describe('hubot/es2015', function () {
     sinon.stub(Hubot, 'Robot')
 
     expect(loadBot).to.be.a('function')
-    Hubot.loadBot('adapterPath', 'adapterName', 'enableHttpd', 'botName', 'botAlias')
-    expect(Hubot.Robot).to.be.called.calledWith('adapterPath', 'adapterName', 'enableHttpd', 'botName', 'botAlias')
+    Hubot.loadBot(null, 'adapter', 'enableHttpd', 'botName', 'botAlias')
+    expect(Hubot.Robot).to.be.called.calledWith(null, 'adapter', 'enableHttpd', 'botName', 'botAlias')
   })
 })

--- a/test/es2015_test.js
+++ b/test/es2015_test.js
@@ -60,7 +60,7 @@ describe('hubot/es2015', function () {
     mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
 
     class MyRobot extends Robot {}
-    const robot = new MyRobot(null, 'mock-adapter', false, 'TestHubot')
+    const robot = new MyRobot('mock-adapter', false, 'TestHubot')
     await robot.loadAdapter()
     expect(robot).to.be.an.instanceof(Robot)
     expect(robot.name).to.equal('TestHubot')

--- a/test/fixtures/MockAdapter.coffee
+++ b/test/fixtures/MockAdapter.coffee
@@ -1,0 +1,10 @@
+{ Adapter } = require "../../index.js"
+class MockAdapter extends Adapter
+    constructor: (robot, @options) ->
+        super robot
+        @name = "MockAdapter"
+    run: ->
+        @emit "connected"
+
+module.exports.use = (robot) ->
+    new MockAdapter robot

--- a/test/fixtures/MockAdapter.mjs
+++ b/test/fixtures/MockAdapter.mjs
@@ -36,4 +36,8 @@ class MockAdapter extends Adapter {
 export {
   MockAdapter
 }
-export default robot => new MockAdapter(robot)
+export default {
+  use (robot) {
+    return new MockAdapter(robot)
+  }
+}

--- a/test/fixtures/MockAdapter.mjs
+++ b/test/fixtures/MockAdapter.mjs
@@ -1,0 +1,39 @@
+'use strict'
+
+import { Adapter } from '../../es2015.js' // eslint-disable-line import/no-unresolved
+
+class MockAdapter extends Adapter {
+  constructor (robot) {
+    super(robot)
+    this.name = 'MockAdapter'
+  }
+
+  send (envelope, ...strings) {
+    this.emit('send', envelope, strings)
+  }
+
+  reply (envelope, ...strings) {
+    this.emit('reply', envelope, strings)
+  }
+
+  topic (envelope, ...strings) {
+    this.emit('topic', envelope, strings)
+  }
+
+  play (envelope, ...strings) {
+    this.emit('play', envelope, strings)
+  }
+
+  run () {
+    // This is required to get the scripts loaded
+    this.emit('connected')
+  }
+
+  close () {
+    this.emit('closed')
+  }
+}
+export {
+  MockAdapter
+}
+export default robot => new MockAdapter(robot)

--- a/test/fixtures/TestScript.coffee
+++ b/test/fixtures/TestScript.coffee
@@ -1,0 +1,9 @@
+# Description: A test script for the robot to load
+#
+# Commands:
+#   hubot test - Responds with a test response
+#
+
+module.exports = (robot) ->
+  robot.respond 'test', (res) ->
+    res.send 'test response from coffeescript'

--- a/test/fixtures/TestScript.js
+++ b/test/fixtures/TestScript.js
@@ -1,0 +1,13 @@
+'use strict'
+
+// Description: A test script for the robot to load
+//
+// Commands:
+//   hubot test - Responds with a test response
+//
+
+module.exports = robot => {
+  robot.respond('test', res => {
+    res.send('test response')
+  })
+}

--- a/test/middleware_test.js
+++ b/test/middleware_test.js
@@ -345,14 +345,15 @@ describe('Middleware', function () {
   // Any new fields that are exposed to middleware should be explicitly
   // tested for.
   describe('Public Middleware APIs', function () {
-    beforeEach(function () {
+    beforeEach(async function () {
       mockery.enable({
         warnOnReplace: false,
         warnOnUnregistered: false
       })
-      mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter'))
+      mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
       process.env.EXPRESS_PORT = 0
       this.robot = new Robot(null, 'mock-adapter', true, 'TestHubot')
+      await this.robot.loadAdapter()
       this.robot.run
 
       // Re-throw AssertionErrors for clearer test failures

--- a/test/middleware_test.js
+++ b/test/middleware_test.js
@@ -352,7 +352,7 @@ describe('Middleware', function () {
       })
       mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
       process.env.EXPRESS_PORT = 0
-      this.robot = new Robot(null, 'mock-adapter', true, 'TestHubot')
+      this.robot = new Robot('mock-adapter', true, 'TestHubot')
       await this.robot.loadAdapter()
       this.robot.run
 

--- a/test/robot_test.js
+++ b/test/robot_test.js
@@ -30,7 +30,7 @@ describe('Robot', function () {
     })
     mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
     process.env.EXPRESS_PORT = 0
-    this.robot = new Robot(null, 'mock-adapter', true, 'TestHubot')
+    this.robot = new Robot('mock-adapter', true, 'TestHubot')
     this.robot.alias = 'Hubot'
     await this.robot.loadAdapter()
     this.robot.run()
@@ -1087,9 +1087,9 @@ describe('Robot ES6', () => {
   let robot = null
   beforeEach(async () => {
     process.env.EXPRESS_PORT = 0
-    robot = new Robot('./test/fixtures/', 'MockAdapter.mjs', true, 'TestHubot')
+    robot = new Robot('MockAdapter', true, 'TestHubot')
     robot.alias = 'Hubot'
-    await robot.loadAdapter()
+    await robot.loadAdapter('./test/fixtures/MockAdapter.mjs')
     robot.loadFile(path.resolve('./test/fixtures/'), 'TestScript.js')
     robot.run()
   })
@@ -1114,9 +1114,9 @@ describe('Robot Coffeescript', () => {
   let robot = null
   beforeEach(async () => {
     process.env.EXPRESS_PORT = 0
-    robot = new Robot('./test/fixtures/', 'MockAdapter.coffee', true, 'TestHubot')
+    robot = new Robot('MockAdapter', true, 'TestHubot')
     robot.alias = 'Hubot'
-    await robot.loadAdapter()
+    await robot.loadAdapter('./test/fixtures/MockAdapter.coffee')
     robot.loadFile(path.resolve('./test/fixtures/'), 'TestScript.coffee')
     robot.run()
   })

--- a/test/robot_test.js
+++ b/test/robot_test.js
@@ -23,15 +23,16 @@ const mockery = require('mockery')
 const path = require('path')
 
 describe('Robot', function () {
-  beforeEach(function () {
+  beforeEach(async function () {
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false
     })
-    mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter'))
+    mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
     process.env.EXPRESS_PORT = 0
     this.robot = new Robot(null, 'mock-adapter', true, 'TestHubot')
     this.robot.alias = 'Hubot'
+    await this.robot.loadAdapter()
     this.robot.run()
 
     // Re-throw AssertionErrors for clearer test failures
@@ -388,8 +389,8 @@ describe('Robot', function () {
         this.sandbox.stub(module, '_load').returns(script)
         this.sandbox.stub(this.robot, 'parseHelp')
 
-        this.robot.loadFile('./scripts', 'test-script.js')
-        expect(module._load).to.have.been.calledWith(path.join('scripts', 'test-script'))
+        this.robot.loadFile('./scripts', 'TestScript.js')
+        expect(module._load).to.have.been.calledWith(path.join('scripts', 'TestScript'))
       })
 
       describe('proper script', function () {
@@ -402,13 +403,13 @@ describe('Robot', function () {
         })
 
         it('should call the script with the Robot', function () {
-          this.robot.loadFile('./scripts', 'test-script.js')
+          this.robot.loadFile('./scripts', 'TestScript.js')
           expect(this.script).to.have.been.calledWith(this.robot)
         })
 
         it('should parse the script documentation', function () {
-          this.robot.loadFile('./scripts', 'test-script.js')
-          expect(this.robot.parseHelp).to.have.been.calledWith(path.join('scripts', 'test-script.js'))
+          this.robot.loadFile('./scripts', 'TestScript.js')
+          expect(this.robot.parseHelp).to.have.been.calledWith(path.join('scripts', 'TestScript.js'))
         })
       })
 
@@ -423,13 +424,13 @@ describe('Robot', function () {
 
         it('logs a warning for a .js file', function () {
           sinon.stub(this.robot.logger, 'warning')
-          this.robot.loadFile('./scripts', 'test-script.js')
+          this.robot.loadFile('./scripts', 'TestScript.js')
           expect(this.robot.logger.warning).to.have.been.called
         })
 
         it('logs a warning for a .mjs file', function () {
           sinon.stub(this.robot.logger, 'warning')
-          this.robot.loadFile('./scripts', 'test-script.mjs')
+          this.robot.loadFile('./scripts', 'TestScript.mjs')
           expect(this.robot.logger.warning).to.have.been.called
         })
       })
@@ -1079,5 +1080,57 @@ describe('Robot', function () {
         })
       })
     })
+  })
+})
+
+describe('Robot ES6', () => {
+  let robot = null
+  beforeEach(async () => {
+    process.env.EXPRESS_PORT = 0
+    robot = new Robot('./test/fixtures/', 'MockAdapter.mjs', true, 'TestHubot')
+    robot.alias = 'Hubot'
+    await robot.loadAdapter()
+    robot.loadFile(path.resolve('./test/fixtures/'), 'TestScript.js')
+    robot.run()
+  })
+  afterEach(() => {
+    robot.shutdown()
+  })
+  it('should load an ES6 module adapter from a file', async () => {
+    const { MockAdapter } = await import('./fixtures/MockAdapter.mjs')
+    expect(robot.adapter).to.be.an.instanceOf(MockAdapter)
+    expect(robot.adapter.name).to.equal('MockAdapter')
+  })
+  it('should respond to a message', async () => {
+    const sent = (envelop, strings) => {
+      expect(strings).to.deep.equal(['test response'])
+    }
+    robot.adapter.on('send', sent)
+    await robot.adapter.receive(new TextMessage('tester', 'hubot test'))
+  })
+})
+
+describe('Robot Coffeescript', () => {
+  let robot = null
+  beforeEach(async () => {
+    process.env.EXPRESS_PORT = 0
+    robot = new Robot('./test/fixtures/', 'MockAdapter.coffee', true, 'TestHubot')
+    robot.alias = 'Hubot'
+    await robot.loadAdapter()
+    robot.loadFile(path.resolve('./test/fixtures/'), 'TestScript.coffee')
+    robot.run()
+  })
+  afterEach(() => {
+    robot.shutdown()
+  })
+  it('should load a CoffeeScript adapter from a file', async () => {
+    expect(robot.adapter.name).to.equal('MockAdapter')
+  })
+  it('should load a coffeescript file and respond to a message', async () => {
+    const sent = (envelop, strings) => {
+      expect(strings).to.deep.equal(['test response from coffeescript'])
+    }
+    robot.adapter.on('send', sent)
+    await robot.adapter.receive(new TextMessage('tester', 'hubot test'))
   })
 })

--- a/test/shell_test.js
+++ b/test/shell_test.js
@@ -12,7 +12,7 @@ const Robot = require('../src/robot')
 
 describe('Shell Adapter', function () {
   beforeEach(async function () {
-    this.robot = new Robot(null, 'shell', false, 'TestHubot')
+    this.robot = new Robot('shell', false, 'TestHubot')
     await this.robot.loadAdapter()
     this.robot.run()
   })

--- a/test/shell_test.js
+++ b/test/shell_test.js
@@ -11,8 +11,9 @@ const expect = chai.expect
 const Robot = require('../src/robot')
 
 describe('Shell Adapter', function () {
-  beforeEach(function () {
+  beforeEach(async function () {
     this.robot = new Robot(null, 'shell', false, 'TestHubot')
+    await this.robot.loadAdapter()
     this.robot.run()
   })
 


### PR DESCRIPTION
- load a .mjs file as an adapter (ES6 import
- load a .coffe, .js or .cjs file from local disk as an adapter (e.g. -f ./adapters/CustomAdapter.coffee, -f ./adapters/CustomAdapter.js, -f ./adapters/CustomAdapter.cjs)
- introduce new cli argument -f (file) that specifies the adapter path and file to load the adapter, e.g. -f ./adapters/CustomAdapter.mjs

BREAKING CHANGE: ES6 import is async, thus loadAdapter was changed to an async function.

#1624 