### PR TITLE
fix(robot): Default to builtin shell adapter

### DIFF
--- a/src/adapters/shell.js
+++ b/src/adapters/shell.js
@@ -17,6 +17,11 @@ const historyPath = '.hubot_history'
 const bold = str => `\x1b[1m${str}\x1b[22m`
 
 class Shell extends Adapter {
+  constructor (robot) {
+    super(robot)
+    this.name = 'Shell'
+  }
+
   send (envelope/* , ...strings */) {
     const strings = [].slice.call(arguments, 1)
 

--- a/src/robot.js
+++ b/src/robot.js
@@ -66,7 +66,7 @@ class Robot {
       this.setupNullRouter()
     }
 
-    this.adapterName = adapter
+    this.adapterName = adapter ?? 'shell'
     this.errorHandlers = []
 
     this.on('error', (err, res) => {

--- a/test/robot_test.js
+++ b/test/robot_test.js
@@ -1083,6 +1083,23 @@ describe('Robot', function () {
   })
 })
 
+describe('Robot Defaults', () => {
+  let robot = null
+  beforeEach(async () => {
+    process.env.EXPRESS_PORT = 0
+    robot = new Robot(null, true, 'TestHubot')
+    robot.alias = 'Hubot'
+    await robot.loadAdapter()
+    robot.run()
+  })
+  afterEach(() => {
+    robot.shutdown()
+  })
+  it('should load the builtin shell adapter by default', async () => {
+    expect(robot.adapter.name).to.equal('Shell')
+  })
+})
+
 describe('Robot ES6', () => {
   let robot = null
   beforeEach(async () => {


### PR DESCRIPTION
Starting Hubot from scratch failed to use the builtin shell adapter by default