### PR TITLE
feat: Use organization scoped adapters like @hubot-friends/hubot-slack

### DIFF
--- a/src/robot.js
+++ b/src/robot.js
@@ -504,7 +504,16 @@ class Robot {
       } else if (['.mjs'].includes(ext)) {
         this.adapter = await this.importAdapterFrom(pathToFileURL(path.resolve(adapterPath)).href)
       } else {
-        this.adapter = this.requireAdapterFrom(`hubot-${this.adapterName}`)
+        const adapterPathInCurrentWorkingDirectory = this.adapterName
+        try {
+          this.adapter = this.requireAdapterFrom(adapterPathInCurrentWorkingDirectory)
+        } catch (err) {
+          if (err.name === 'SyntaxError' && err.message.includes('Cannot use import statement outside a module')) {
+            this.adapter = await this.importAdapterFrom(adapterPathInCurrentWorkingDirectory)
+          } else {
+            throw err
+          }
+        }
       }
     } catch (err) {
       this.logger.error(`Cannot load adapter ${adapterPath ?? '[no path set]'} ${this.adapterName} - ${err}`)

--- a/test/es2015_test.js
+++ b/test/es2015_test.js
@@ -60,7 +60,7 @@ describe('hubot/es2015', function () {
     mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
 
     class MyRobot extends Robot {}
-    const robot = new MyRobot('mock-adapter', false, 'TestHubot')
+    const robot = new MyRobot('hubot-mock-adapter', false, 'TestHubot')
     await robot.loadAdapter()
     expect(robot).to.be.an.instanceof(Robot)
     expect(robot.name).to.equal('TestHubot')

--- a/test/middleware_test.js
+++ b/test/middleware_test.js
@@ -352,7 +352,7 @@ describe('Middleware', function () {
       })
       mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
       process.env.EXPRESS_PORT = 0
-      this.robot = new Robot('mock-adapter', true, 'TestHubot')
+      this.robot = new Robot('hubot-mock-adapter', true, 'TestHubot')
       await this.robot.loadAdapter()
       this.robot.run
 

--- a/test/robot_test.js
+++ b/test/robot_test.js
@@ -30,7 +30,7 @@ describe('Robot', function () {
     })
     mockery.registerMock('hubot-mock-adapter', require('./fixtures/mock-adapter.js'))
     process.env.EXPRESS_PORT = 0
-    this.robot = new Robot('mock-adapter', true, 'TestHubot')
+    this.robot = new Robot('hubot-mock-adapter', true, 'TestHubot')
     this.robot.alias = 'Hubot'
     await this.robot.loadAdapter()
     this.robot.run()


### PR DESCRIPTION
BREAKING CHANGE: This change now requires you to include hubot- when specifying hubot adapters.