### PR TITLE
fix: ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows

### DIFF
--- a/test/hubot_test.js
+++ b/test/hubot_test.js
@@ -13,7 +13,7 @@ const { TextMessage, User } = require('../index.js')
 describe('hubot', () => {
   let hubot
   before(() => {
-    process.env.HUBOT_ADAPTER = path.join(__dirname, './fixtures/MockAdapter.mjs')
+    process.env.HUBOT_ADAPTER = path.resolve(__dirname, 'fixtures', 'MockAdapter.mjs')
     hubot = require('../bin/hubot.js')
   })
   after(() => {


### PR DESCRIPTION
Got the following error message in a unit test on Windows:

Cannot load adapter [no path set] D:\\a\\hubot\\hubot\\test\\fixtures\\MockAdapter.mjs - Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'"