### PR TITLE
fix: ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows

### DIFF
--- a/test/hubot_test.js
+++ b/test/hubot_test.js
@@ -13,7 +13,7 @@ const { TextMessage, User } = require('../index.js')
 describe('hubot', () => {
   let hubot
   before(() => {
-    process.env.HUBOT_ADAPTER = path.join(__dirname, './fixtures/MockAdapter.mjs')
+    process.env.HUBOT_ADAPTER = path.resolve(__dirname, 'fixtures', 'MockAdapter.mjs')
     hubot = require('../bin/hubot.js')
   })
   after(() => {

--- a/test/hubot_test.js
+++ b/test/hubot_test.js
@@ -13,7 +13,7 @@ const { TextMessage, User } = require('../index.js')
 describe('hubot', () => {
   let hubot
   before(() => {
-    process.env.HUBOT_ADAPTER = path.resolve(__dirname, 'fixtures', 'MockAdapter.mjs')
+    process.env.HUBOT_ADAPTER = path.join('..', 'test', 'fixtures', 'MockAdapter.mjs')
     hubot = require('../bin/hubot.js')
   })
   after(() => {


### PR DESCRIPTION
Creating an absolute path includes the drive letter (e.g. D://) on Windows which breaks Hubot's loadAdapter strategy.