### PR TITLE
Fix clobbered helper methods on msg object

### DIFF
--- a/src/Robot.mjs
+++ b/src/Robot.mjs
@@ -229,7 +229,8 @@ class Robot {
     }
 
     this.listen(isCatchAllMessage, options, async msg => {
-      await callback(msg.message)
+      msg.message = msg.message.message
+      await callback(msg)
     })
   }
 


### PR DESCRIPTION
Helper methods on the `msg` object are being clobbered. This removes functions like reply, and random from `msg` passed to the callback.