### PR TITLE
feat: load typescript scripts

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.x
+          - 23.x
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
-      - run: npm test
+      - run: npm test --experimental-strip-types
   e2etest:
     name: E2E Test
     needs:

--- a/src/Robot.mjs
+++ b/src/Robot.mjs
@@ -341,6 +341,10 @@ class Robot {
     return result
   }
 
+  async loadts (filePath) {
+    return this.loadmjs(filePath)
+  }
+
   async loadjs (filePath) {
     const forImport = this.prepareForImport(filePath)
     const script = (await import(forImport)).default
@@ -364,7 +368,7 @@ class Robot {
     const full = path.join(filepath, path.basename(filename))
 
     // see https://github.com/hubotio/hubot/issues/1355
-    if (['js', 'mjs'].indexOf(ext) === -1) {
+    if (['js', 'mjs', 'ts'].indexOf(ext) === -1) {
       this.logger.debug(`Skipping unsupported file type ${full}`)
       return null
     }

--- a/test/Robot_test.mjs
+++ b/test/Robot_test.mjs
@@ -320,6 +320,11 @@ describe('Robot', () => {
       assert.deepEqual(robot.hasLoadedTestMjsScript, true)
     })
 
+    it('should load an .ts file', async () => {
+      await robot.loadFile(path.resolve('./test/fixtures'), 'TestScript.ts')
+      assert.deepEqual(robot.hasLoadedTestTsScript, true)
+    })
+
     describe('proper script', () => {
       it('should parse the script documentation', async () => {
         await robot.loadFile(path.resolve('./test/fixtures'), 'TestScript.js')

--- a/test/fixtures/TestScript.ts
+++ b/test/fixtures/TestScript.ts
@@ -1,0 +1,14 @@
+'use strict'
+
+// Description: A test .ts script for the robot to load
+//
+// Commands:
+//   hubot test ts - Responds with a test response from a .ts script
+//
+
+export default robot => {
+  robot.hasLoadedTestTsScript = true
+  robot.respond(/test$/, async res => {
+    await res.reply('test response from .ts script')
+  })
+}


### PR DESCRIPTION
when using modern nodejs with --experimental-strip-types, typescript can be loaded directly
