### PR TITLE
feat: Enable setting a  object on robot that can then be used

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ script
 www
 _site
 *.tgz
+configuration

--- a/bin/Hubot.mjs
+++ b/bin/Hubot.mjs
@@ -134,6 +134,7 @@ async function loadExternalScripts () {
 }
 
 (async () => {
+  await robot.load(pathResolve('.', 'configuration'))
   await robot.loadAdapter(options.file)
   if (options.version) {
     console.log(robot.version)

--- a/configuration/Config.mjs
+++ b/configuration/Config.mjs
@@ -1,0 +1,3 @@
+export default async robot => {
+  robot.config = {}
+}

--- a/test/Configuration_test.mjs
+++ b/test/Configuration_test.mjs
@@ -1,0 +1,21 @@
+'use strict'
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { Robot } from '../index.mjs'
+import { resolve } from 'node:path'
+describe('Configuration', () => {
+  describe('#robot', () => {
+    let robot = null
+    beforeEach(() => {
+      robot = new Robot(null, false, 'TestHubot')
+    })
+    afterEach(() => {
+      robot.shutdown()
+    })
+    it('Load files from configuration folder', async () => {
+      await robot.load(resolve('.', 'configuration'))
+      assert.ok(robot.config !== undefined)
+    })
+  })
+})


### PR DESCRIPTION
# Brackground

The hubot-slack adapter uses the slack/web-api module when uses axios for making http requests. It disables axios proxy support. So in order to use a proxy, an HTTP Agent needs to be configured and passed to the `WebClient` constructor which is done in `hubot-slack`.

# Design

Externalize configuration of Hubot by adding a file loading step prior to loading the adapter which allows the user to create files that will be loaded and allowed to set options other the robot instance that can then be used in adapters.